### PR TITLE
Use more distinct keys in Curve Data checker

### DIFF
--- a/src/variety/curvedata.js
+++ b/src/variety/curvedata.js
@@ -353,11 +353,17 @@ CurveData: {
 			for(var x = 0; x < w; x++) {
 				var id = y*w+x;
 				if(hold===null && (this.bits[id] & 1)) {
-					hold = id;
+					hold = [id];
 				} else if (hold!==null && this.bits[id]!==5) {
-					this.connections[hold].right = [id];
-					this.connections[id].left = [hold];
-					hold = (this.bits[id] & 1) ? id : null;
+					hold.push(id);
+					if(!(this.bits[id] & 1)) {
+						var conns = this.connections;
+						hold.forEach(function (pos, index) {
+							conns[pos].left = hold.slice(0, index);
+							conns[pos].right = hold.slice(index);
+						});
+						hold = null;
+					}
 				}
 			}
 		}
@@ -367,11 +373,17 @@ CurveData: {
 			for(var y = 0; y < h; y++) {
 				var id = y*w+x;
 				if(hold===null && (this.bits[id] & 2)) {
-					hold = id;
+					hold = [id];
 				} else if (hold!==null && this.bits[id]!==10) {
-					this.connections[hold].bottom = [id];
-					this.connections[id].top = [hold];
-					hold = (this.bits[id] & 2) ? id : null;
+					hold.push(id);
+					if(!(this.bits[id] & 2)) {
+						var conns = this.connections;
+						hold.forEach(function (pos, index) {
+							conns[pos].top = hold.slice(0, index);
+							conns[pos].bottom = hold.slice(index);
+						});
+						hold = null;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #66.

Instead of only using the four immediate neighbours of a node, the connections array now contains all positions along a certain axis. [This puzzle](https://puzz.link/p?curvedata/20/20/0zzzzzzzzzzzzzzzzzzzy/20/20/fffffffffbfffffffffbfffffffffbfffffffffbfffffffffbfffffffffbfffffffffbfffffffffbfffffffffbfffffffffbfffffffffbfffffffffbfffffffffbfffffffffbfffffffffbff7ffffffbfffffffffbfffffffffbfffffffffb5555555551) can now entirely avoid iterating through the different combinations.