### PR TITLE
Prevent drawing curves in moving puzzles

### DIFF
--- a/src/puzzle/Piece.js
+++ b/src/puzzle/Piece.js
@@ -625,6 +625,22 @@ pzpr.classmgr.makeCommon({
 		return false;
 	},
 
+	// Check if adding a line would create a corner in the side cells.
+	checkFormCurve : function(num) {
+		if (num===0) { return false; }
+		for(var i = 0; i <= 1; i++) {
+			if(this.isVert() && (this.sidecell[i].adjborder.top.isLine() ||
+			this.sidecell[i].adjborder.bottom.isLine())) {
+				return true;
+			}
+			if(!this.isVert() && (this.sidecell[i].adjborder.left.isLine() ||
+			this.sidecell[i].adjborder.right.isLine())) {
+				return true;
+			}
+		}
+		return false;
+	},
+
 	// cell.setQues => setCombinedLineから呼ばれる関数 (exist->ex)
 	//  -> cellidの片方がnullになっていることを考慮していません
 	isLineEX : function(){

--- a/src/puzzle/Piece.js
+++ b/src/puzzle/Piece.js
@@ -470,6 +470,20 @@ pzpr.classmgr.makeCommon({
 		return cblist;
 	},
 
+	//------------------------------------------------------------------------------------
+	// cell.getOrthogonalCell()  Get an adjacent cell in the direction of the target cell.
+	//------------------------------------------------------------------------------------
+	getOrthogonalCell : function(target) {
+		if(this.bx === target.bx) {
+			if(this.by === target.by) { return this.board.emptycell; }
+			return this.by > target.by ? this.adjacent.top : this.adjacent.bottom;
+		} else if(this.by === target.by) {
+			return this.bx > target.bx ? this.adjacent.left : this.adjacent.right;
+		}
+
+		return this.board.emptycell;
+	},
+
 	//--------------------------------------------------------------------------------
 	// cell.eraseMovedLines()  移動系パズルの丸が消えたとき等、領域に含まれる線を消去する
 	//--------------------------------------------------------------------------------

--- a/src/variety-common/MouseInput.js
+++ b/src/variety-common/MouseInput.js
@@ -572,12 +572,14 @@ MouseEvent:{
 		else if(this.mousemove && !cell0.isnull && !cell.isDestination()){
 			var border = this.prevPos.getnb(pos);
 			if(!border.isnull && ((!border.isLine() && cell.lcnt===0) || (border.isLine() && cell0.lcnt===1))){
-				this.mouseCell = cell;
-				this.prevPos = pos;
 				var old = border.isLine();
 				if(!old){ border.setLine();}else{ border.removeLine();}
-				if(old===border.isLine()){ this.mousereset(); cell0.draw(); return;}
-				border.draw();
+				this.puzzle.opemgr.changeflag = true;
+				if(old!==border.isLine()){
+					this.mouseCell = cell;
+					this.prevPos = pos;
+					border.draw();
+				}
 			}
 		}
 	},

--- a/src/variety-common/MouseInput.js
+++ b/src/variety-common/MouseInput.js
@@ -558,27 +558,34 @@ MouseEvent:{
 		this.prevPos = pos;
 	},
 	inputMoveLine : function(){
-		var cell = this.getcell();
-		if(cell.isnull){ return;}
+		var moving = true;
+		var targetCell = this.getcell();
 
-		var cell0 = this.mouseCell, pos = cell.getaddr();
-		/* 初回はこの中に入ってきます。 */
-		if(this.mousestart && cell.isDestination()){
-			this.mouseCell = cell;
-			this.prevPos = pos;
-			cell.draw();
-		}
-		/* 移動中の場合 */
-		else if(this.mousemove && !cell0.isnull && !cell.isDestination()){
-			var border = this.prevPos.getnb(pos);
-			if(!border.isnull && ((!border.isLine() && cell.lcnt===0) || (border.isLine() && cell0.lcnt===1))){
-				var old = border.isLine();
-				if(!old){ border.setLine();}else{ border.removeLine();}
-				this.puzzle.opemgr.changeflag = true;
-				if(old!==border.isLine()){
-					this.mouseCell = cell;
-					this.prevPos = pos;
-					border.draw();
+		while(moving) {
+			moving = false;
+			var cell = this.mouseCell && !this.mousestart ? this.mouseCell.getOrthogonalCell(targetCell) : targetCell;
+			if(cell.isnull){ return;}
+
+			var cell0 = this.mouseCell, pos = cell.getaddr();
+			/* 初回はこの中に入ってきます。 */
+			if(this.mousestart && cell.isDestination()){
+				this.mouseCell = cell;
+				this.prevPos = pos;
+				cell.draw();
+			}
+			/* 移動中の場合 */
+			else if(this.mousemove && !cell0.isnull && !cell.isDestination()){
+				var border = this.prevPos.getnb(pos);
+				if(!border.isnull && ((!border.isLine() && cell.lcnt===0) || (border.isLine() && cell0.lcnt===1))){
+					var old = border.isLine();
+					if(!old){ border.setLine();}else{ border.removeLine();}
+					this.puzzle.opemgr.changeflag = true;
+					if(old!==border.isLine()){
+						this.mouseCell = cell;
+						this.prevPos = pos;
+						border.draw();
+						moving = true;
+					}
 				}
 			}
 		}

--- a/src/variety/bonsan.js
+++ b/src/variety/bonsan.js
@@ -142,6 +142,11 @@ Cell:{
 	}
 },
 
+Border:{
+	prehook : {
+		line : function(num){ return this.puzzle.execConfig('dispmove') && this.checkFormCurve(num); }
+	}
+},
 "Border@satogaeri":{
 	posthook : {
 		line : function(num){

--- a/src/variety/herugolf.js
+++ b/src/variety/herugolf.js
@@ -58,28 +58,35 @@ MouseEvent:{
 	},
 
 	inputMoveLine : function(){
-		var cell = this.getcell();
-		if(cell.isnull){ return;}
+		var moving = true;
+		var targetCell = this.getcell();
 
-		var cell0 = this.mouseCell, pos = cell.getaddr();
-		/* 初回はこの中に入ってきます。 */
-		if(this.mousestart && cell.isDestination()){
-			this.mouseCell = cell;
-			this.prevPos = pos;
-			cell.draw();
-		}
-		/* 移動中の場合 */
-		else if(this.mousemove && !cell0.isnull && !cell.isDestination()){
-			var border = this.prevPos.getnb(pos);
-			if(!border.isnull && ((!border.isLine() && cell.lcnt===0) || (border.isLine() && cell0.lcnt===1))){
-				/* この条件を追加 */
-				if(border.isLine() || border.sidecell[0].distance>0 || border.sidecell[1].distance>0){
-					var old = border.isLine();
-					if(!old){ border.setLine();}else{ border.removeLine();}
-					if(old!==border.isLine()){
-						this.mouseCell = cell;
-						this.prevPos = pos;
-						border.draw();
+		while(moving) {
+			moving = false;
+			var cell = this.mouseCell && !this.mousestart ? this.mouseCell.getOrthogonalCell(targetCell) : targetCell;
+			if(cell.isnull){ return;}
+
+			var cell0 = this.mouseCell, pos = cell.getaddr();
+			/* 初回はこの中に入ってきます。 */
+			if(this.mousestart && cell.isDestination()){
+				this.mouseCell = cell;
+				this.prevPos = pos;
+				cell.draw();
+			}
+			/* 移動中の場合 */
+			else if(this.mousemove && !cell0.isnull && !cell.isDestination()){
+				var border = this.prevPos.getnb(pos);
+				if(!border.isnull && ((!border.isLine() && cell.lcnt===0) || (border.isLine() && cell0.lcnt===1))){
+					/* この条件を追加 */
+					if(border.isLine() || border.sidecell[0].distance>0 || border.sidecell[1].distance>0){
+						var old = border.isLine();
+						if(!old){ border.setLine();}else{ border.removeLine();}
+						if(old!==border.isLine()){
+							this.mouseCell = cell;
+							this.prevPos = pos;
+							border.draw();
+							moving = true;
+						}
 					}
 				}
 			}

--- a/src/variety/herugolf.js
+++ b/src/variety/herugolf.js
@@ -74,10 +74,13 @@ MouseEvent:{
 			if(!border.isnull && ((!border.isLine() && cell.lcnt===0) || (border.isLine() && cell0.lcnt===1))){
 				/* この条件を追加 */
 				if(border.isLine() || border.sidecell[0].distance>0 || border.sidecell[1].distance>0){
-					this.mouseCell = cell;
-					this.prevPos = pos;
-					if(!border.isLine()){ border.setLine();}else{ border.removeLine();}
-					border.draw();
+					var old = border.isLine();
+					if(!old){ border.setLine();}else{ border.removeLine();}
+					if(old!==border.isLine()){
+						this.mouseCell = cell;
+						this.prevPos = pos;
+						border.draw();
+					}
 				}
 			}
 		}
@@ -202,6 +205,14 @@ Cell:{
 	getDeparture : function(){
 		var bd = this.board, path = this.path;
 		return (path!==null ? path.departure : bd.emptycell);
+	}
+},
+Border:{
+	prehook : {
+		line : function(num){
+			return this.puzzle.execConfig('dispmove') && this.checkFormCurve(num) &&
+			!this.sidecell[0].isViaPoint() && !this.sidecell[1].isViaPoint();
+		}
 	}
 },
 Board:{

--- a/src/variety/yosenabe.js
+++ b/src/variety/yosenabe.js
@@ -150,6 +150,13 @@ CellList:{
 		return count;
 	}
 },
+
+Border:{
+	prehook : {
+		line : function(num){ return this.puzzle.execConfig('dispmove') && this.checkFormCurve(num); }
+	}
+},
+
 Board:{
 	cols : 8,
 	rows : 8,


### PR DESCRIPTION
https://github.com/robx/pzprjs/issues/1#issuecomment-494007516

This patch also prevents objects that are being dragged from losing focus (by not changing `mouseCell` when line placement fails).