### PR TITLE
Rework the buttons below the puzzle

### DIFF
--- a/src-ui/css/ui.css
+++ b/src-ui/css/ui.css
@@ -52,7 +52,9 @@ h2#title {
   background: #afafaf;
   background: linear-gradient(to bottom, #afafaf, #cccccc);
 }
-
+.btn:disabled {
+  color: silver;
+}
 .btn-ok {
   background: blue;
   background: linear-gradient(to bottom, #afafff, blue);

--- a/src-ui/css/ui.css
+++ b/src-ui/css/ui.css
@@ -90,10 +90,6 @@ h2#title {
   background: linear-gradient(to bottom, #cc0000, red);
 }
 
-#btnarea div#btnclear {
-  color: red;
-}
-
 /* 管理領域 */
 div#menuboard {
   width: 90%;

--- a/src-ui/js/ui/MenuArea.js
+++ b/src-ui/js/ui/MenuArea.js
@@ -353,10 +353,10 @@ ui.menuarea = {
 		ui.puzzle.rejectCurrentTrial();
 	},
 	ansclear: function() {
-		this.answerclear();
+		ui.puzzle.ansclear();
 	},
 	subclear: function() {
-		this.submarkclear();
+		ui.puzzle.subclear();
 	},
 	toolarea: function() {
 		ui.menuconfig.set("toolarea", !ui.menuconfig.get("toolarea"));
@@ -416,25 +416,5 @@ ui.menuarea = {
 		}
 		this.stopHovering();
 		ui.notify.alert(str);
-	},
-	answerclear: function() {
-		this.stopHovering();
-		ui.notify.confirm(
-			"解答を消去しますか？",
-			"Do you want to erase the answer?",
-			function() {
-				ui.puzzle.ansclear();
-			}
-		);
-	},
-	submarkclear: function() {
-		this.stopHovering();
-		ui.notify.confirm(
-			"補助記号を消去しますか？",
-			"Do you want to erase the auxiliary marks?",
-			function() {
-				ui.puzzle.subclear();
-			}
-		);
 	}
 };

--- a/src-ui/js/ui/MenuArea.js
+++ b/src-ui/js/ui/MenuArea.js
@@ -230,13 +230,16 @@ ui.menuarea = {
 		}
 	},
 	setdisplay: function(idname) {
-		if (idname === "trialmode") {
+		if (idname === "operation") {
+			getEL("menu_subclear").className = ui.puzzle.board.disable_subclear
+				? "disabled"
+				: "";
+		} else if (idname === "trialmode") {
 			var trial = ui.puzzle.board.trialstage > 0;
 			getEL("menu_adjust").className = trial ? "disabled" : "";
 			getEL("menu_turnflip").className = trial ? "disabled" : "";
-		}
-
-		if (idname === "toolarea") {
+			getEL("menu_ansclear").className = trial ? "disabled" : "";
+		} else if (idname === "toolarea") {
 			var str;
 			if (!ui.menuconfig.get("toolarea")) {
 				str = ui.selectStr("ツールエリアを表示", "Show tool area");
@@ -348,6 +351,12 @@ ui.menuarea = {
 	},
 	rejectCurrentTrial: function() {
 		ui.puzzle.rejectCurrentTrial();
+	},
+	ansclear: function() {
+		this.answerclear();
+	},
+	subclear: function() {
+		this.submarkclear();
 	},
 	toolarea: function() {
 		ui.menuconfig.set("toolarea", !ui.menuconfig.get("toolarea"));

--- a/src-ui/js/ui/ToolArea.js
+++ b/src-ui/js/ui/ToolArea.js
@@ -33,7 +33,6 @@ ui.toolarea = {
 			return function(e) {
 				toolarea[role](e);
 				if (e.type !== "click") {
-					e.preventDefault();
 					e.stopPropagation();
 				}
 			};

--- a/src-ui/js/ui/ToolArea.js
+++ b/src-ui/js/ui/ToolArea.js
@@ -195,6 +195,7 @@ ui.toolarea = {
 			var opemgr = ui.puzzle.opemgr;
 			getEL("btnundo").disabled = !opemgr.enableUndo;
 			getEL("btnredo").disabled = !opemgr.enableRedo;
+			getEL("btntriale").disabled = opemgr.atStartOfTrial();
 		} else if (idname === "trialmode") {
 			var trialstage = ui.puzzle.board.trialstage;
 			getEL("btntrial").disabled = trialstage > 0;

--- a/src-ui/js/ui/ToolArea.js
+++ b/src-ui/js/ui/ToolArea.js
@@ -194,7 +194,9 @@ ui.toolarea = {
 		if (idname === "operation") {
 			var opemgr = ui.puzzle.opemgr;
 			getEL("btnundo").disabled = !opemgr.enableUndo;
+			getEL("btnundoall").disabled = !opemgr.enableUndo;
 			getEL("btnredo").disabled = !opemgr.enableRedo;
+			getEL("btnredoall").disabled = !opemgr.enableRedo;
 			getEL("btntriale").disabled = opemgr.atStartOfTrial();
 		} else if (idname === "trialmode") {
 			var trialstage = ui.puzzle.board.trialstage;
@@ -285,6 +287,9 @@ ui.toolarea = {
 	answercheck: function() {
 		ui.menuarea.answercheck();
 	},
+	undoall: function() {
+		ui.puzzle.undoall();
+	},
 	undo: function() {
 		ui.undotimer.startUndo();
 	},
@@ -296,6 +301,9 @@ ui.toolarea = {
 	},
 	redostop: function() {
 		ui.undotimer.stopRedo();
+	},
+	redoall: function() {
+		ui.puzzle.redoall();
 	},
 	ansclear: function() {
 		ui.menuarea.answerclear();

--- a/src-ui/js/ui/ToolArea.js
+++ b/src-ui/js/ui/ToolArea.js
@@ -196,12 +196,12 @@ ui.toolarea = {
 	setdisplay: function(idname) {
 		if (idname === "operation") {
 			var opemgr = ui.puzzle.opemgr;
-			getEL("btnundo").style.color = !opemgr.enableUndo ? "silver" : "";
-			getEL("btnredo").style.color = !opemgr.enableRedo ? "silver" : "";
+			getEL("btnundo").disabled = !opemgr.enableUndo;
+			getEL("btnredo").disabled = !opemgr.enableRedo;
 		} else if (idname === "trialmode") {
 			var trialstage = ui.puzzle.board.trialstage;
 			getEL("btnclear").style.display = trialstage > 0 ? "none" : "";
-			getEL("btntrial").style.color = trialstage > 0 ? "silver" : "";
+			getEL("btntrial").disabled = trialstage > 0;
 			getEL("btntrialarea").style.display = trialstage > 0 ? "block" : "none";
 
 			getEL("btntrialr").style.display = trialstage <= 1 ? "" : "none";

--- a/src-ui/js/ui/ToolArea.js
+++ b/src-ui/js/ui/ToolArea.js
@@ -200,10 +200,6 @@ ui.toolarea = {
 			var trialstage = ui.puzzle.board.trialstage;
 			getEL("btntrial").disabled = trialstage > 0;
 			getEL("btntrialarea").style.display = trialstage > 0 ? "block" : "none";
-
-			getEL("btntrialr").style.display = trialstage <= 1 ? "" : "none";
-			getEL("btntrialr2").style.display = trialstage > 1 ? "" : "none";
-			getEL("btntrialra").style.display = trialstage > 1 ? "" : "none";
 		} else if (this.items === null || !this.items[idname]) {
 			/* DO NOTHING */
 		} else if (ui.menuconfig.valid(idname)) {
@@ -331,9 +327,6 @@ ui.toolarea = {
 		ui.puzzle.acceptTrial();
 	},
 	rejectTrial: function() {
-		ui.puzzle.rejectTrial();
-	},
-	rejectCurrentTrial: function() {
 		ui.puzzle.rejectCurrentTrial();
 	},
 

--- a/src-ui/js/ui/ToolArea.js
+++ b/src-ui/js/ui/ToolArea.js
@@ -138,9 +138,6 @@ ui.toolarea = {
 		pzpr.util.unselectable(getEL("btnarea"));
 
 		this.setdisplay("operation");
-		getEL("btnclear2").style.display = !ui.puzzle.board.disable_subclear
-			? ""
-			: "none";
 		getEL("btncircle").style.display =
 			ui.puzzle.pid === "pipelinkr" ? "" : "none";
 		getEL("btncolor").style.display =
@@ -200,7 +197,6 @@ ui.toolarea = {
 			getEL("btnredo").disabled = !opemgr.enableRedo;
 		} else if (idname === "trialmode") {
 			var trialstage = ui.puzzle.board.trialstage;
-			getEL("btnclear").disabled = trialstage > 0;
 			getEL("btntrial").disabled = trialstage > 0;
 			getEL("btntrialarea").style.display = trialstage > 0 ? "block" : "none";
 

--- a/src-ui/js/ui/ToolArea.js
+++ b/src-ui/js/ui/ToolArea.js
@@ -200,7 +200,7 @@ ui.toolarea = {
 			getEL("btnredo").disabled = !opemgr.enableRedo;
 		} else if (idname === "trialmode") {
 			var trialstage = ui.puzzle.board.trialstage;
-			getEL("btnclear").style.display = trialstage > 0 ? "none" : "";
+			getEL("btnclear").disabled = trialstage > 0;
 			getEL("btntrial").disabled = trialstage > 0;
 			getEL("btntrialarea").style.display = trialstage > 0 ? "block" : "none";
 

--- a/src-ui/p.html
+++ b/src-ui/p.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
-<HTML lang="ja">
-<HEAD>
-<META CHARSET="utf-8">
+<html lang="ja">
+<head>
+<meta charset="utf-8">
 <meta name="viewport" content="width=device-width">
 
 <link rel="apple-touch-icon" sizes="180x180" href="./apple-touch-icon.png">
@@ -13,10 +13,10 @@
 <link rel="stylesheet" href="./css/ui.css?<%= git.hash %>" type="text/css">
 <script type="text/javascript" src="./js/pzpr.js?<%= git.hash %>"></script>
 <script type="text/javascript" src="./js/pzpr-ui.js?<%= git.hash %>"></script>
-<TITLE>ぱずぷれv3</TITLE>
-</HEAD>
+<title>puzz.link player</title>
+</head>
 
-<BODY>
+<body>
 
 <div id="main">
 
@@ -619,5 +619,5 @@
 </div>
 <!-- ここまで -->
 
-</BODY>
-</HTML>
+</body>
+</html>

--- a/src-ui/p.html
+++ b/src-ui/p.html
@@ -327,8 +327,10 @@
 
 <div id="btnarea" class="outofboard" style="display:none;">	<!-- Canvas下部のボタン -->
   <button type="button" class="btn btn-ok" id="btncheck" data-button-exec="answercheck">__チェック__Check__</button>
-  <button type="button" class="btn" id="btnundo"    data-press-exec="undo,undostop">__戻__&lt;-__</button
- ><button type="button" class="btn" id="btnredo"    data-press-exec="redo,redostop">__進__-&gt;__</button>
+  <button type="button" class="btn" id="btnundoall" data-button-exec="undoall">&lt;&lt;</button
+ ><button type="button" class="btn" id="btnundo"    data-press-exec="undo,undostop">&lt;</button
+ ><button type="button" class="btn" id="btnredo"    data-press-exec="redo,redostop">&gt;</button
+ ><button type="button" class="btn" id="btnredoall" data-button-exec="redoall">&gt;&gt;</button>
   <button type="button" class="btn" id="btnirowake" data-button-exec="irowake" style="display:none;">__色分けしなおす__Change line colors__</button>
   <button type="button" class="btn" id="btnirowakeblk" data-button-exec="irowake" style="display:none;">__色分けしなおす__Change block colors__</button>
   <button type="button" class="btn" id="btncircle"  data-button-exec="toggledisp">○</button>

--- a/src-ui/p.html
+++ b/src-ui/p.html
@@ -336,11 +336,9 @@
   <button type="button" class="btn" data-disp-pid="stostone" data-press-exec="dropblocks,resetblocks">__ブロックを落とす__Drop blocks__</button>
   <button type="button" class="btn" id="btntrial"   data-button-exec="enterTrial">__仮置きモード__Trial mode__</button>
   <div id="btntrialarea" style="display:none;">
-    <button type="button" class="btn btn-ok" id="btntriala"  data-button-exec="acceptTrial">__仮置き確定__Accept trial__</button>
-    <button type="button" class="btn btn-danger" id="btntrialr"  data-button-exec="rejectTrial">__仮置き破棄__Reject trial__</button>
-    <button type="button" class="btn btn-danger" id="btntrialr2" data-button-exec="rejectCurrentTrial">__仮置き破棄__Reject current trial__</button>
-    <button type="button" class="btn btn-danger" id="btntrialra" data-button-exec="rejectTrial">__全仮置き破棄__Reject all trials__</button>
-    <button type="button" class="btn" id="btntriale"  data-button-exec="enterFurtherTrial">__多重仮置き__Enter further trial__</button>
+    <button type="button" class="btn btn-ok" id="btntriala"  data-button-exec="acceptTrial">__確定__Accept__</button
+   ><button type="button" class="btn btn-danger" id="btntrialr"  data-button-exec="rejectTrial">__破棄__Reject__</button
+   ><button type="button" class="btn" id="btntriale"  data-button-exec="enterFurtherTrial">__多重仮置き__Enter further trial__</button>
   </div>
 </div>
 

--- a/src-ui/p.html
+++ b/src-ui/p.html
@@ -39,6 +39,10 @@
      <li data-popup="adjust" id="menu_adjust"><span>__盤面の調整__Adjust the board__</span></li>
      <li data-popup="turnflip" id="menu_turnflip"><span>__反転・回転__Flip/Turn the board__</span></li>
    </menu></li>
+   <li id="menu_board"><span>__盤面__Board__</span><menu label="__盤面__Board__">
+     <li data-menu-exec="ansclear" id="menu_ansclear"><span>__解答消去__Erase answer__</span></li>
+     <li data-menu-exec="subclear" id="menu_subclear"><span>__補助記号消去__Erase auxiliary marks__</span></li>
+   </menu></li>
    <li id="menu_display"><span>__表示__Display__</span><menu label="__表示__Display__">
      <li data-config="cellsizeval"><span>__表示サイズ__Cell size__</span> -&gt;<menu label="__表示サイズ__Cell size__">
        <li data-value="19"><span>__サイズ 極小__Extra small__</span></li>
@@ -325,8 +329,6 @@
   <button type="button" class="btn btn-ok" id="btncheck" data-button-exec="answercheck">__チェック__Check__</button>
   <button type="button" class="btn" id="btnundo"    data-press-exec="undo,undostop">__戻__&lt;-__</button
  ><button type="button" class="btn" id="btnredo"    data-press-exec="redo,redostop">__進__-&gt;__</button>
-  <button type="button" class="btn" id="btnclear"   data-button-exec="ansclear">__解答消去__Erase answer__</button
- ><button type="button" class="btn" id="btnclear2"  data-button-exec="subclear">__補助消去__Erase aux. marks__</button>
   <button type="button" class="btn" id="btnirowake" data-button-exec="irowake" style="display:none;">__色分けしなおす__Change line colors__</button>
   <button type="button" class="btn" id="btnirowakeblk" data-button-exec="irowake" style="display:none;">__色分けしなおす__Change block colors__</button>
   <button type="button" class="btn" id="btncircle"  data-button-exec="toggledisp">○</button>

--- a/src/puzzle/Operation.js
+++ b/src/puzzle/Operation.js
@@ -474,10 +474,15 @@ pzpr.classmgr.makeCommon({
 
 			this.puzzle.emit("history");
 		},
+		atStartOfTrial: function() {
+			return (
+				this.trialpos.length > 0 &&
+				this.position <= this.trialpos[this.trialpos.length - 1] + 1
+			);
+		},
 		checkenable: function() {
 			if (this.limitTrialUndo && this.trialpos.length > 0) {
-				this.enableUndo =
-					this.position > this.trialpos[this.trialpos.length - 1] + 1;
+				this.enableUndo = !this.atStartOfTrial();
 			} else {
 				this.enableUndo = this.position > 0;
 			}
@@ -763,10 +768,7 @@ pzpr.classmgr.makeCommon({
 		// opemgr.emtiTrial()    trial eventを呼び出す
 		//---------------------------------------------------------------------------
 		enterTrial: function() {
-			if (
-				this.trailpos.length > 0 &&
-				this.trialpos[this.trialpos.length - 1] + 1 === this.position
-			) {
+			if (this.atStartOfTrial()) {
 				return;
 			}
 			this.newOperation();

--- a/src/puzzle/Operation.js
+++ b/src/puzzle/Operation.js
@@ -475,7 +475,7 @@ pzpr.classmgr.makeCommon({
 			this.puzzle.emit("history");
 		},
 		checkenable: function() {
-			if (this.limitTrialUndo) {
+			if (this.limitTrialUndo && this.trialpos.length > 0) {
 				this.enableUndo =
 					this.position > this.trialpos[this.trialpos.length - 1] + 1;
 			} else {
@@ -763,7 +763,10 @@ pzpr.classmgr.makeCommon({
 		// opemgr.emtiTrial()    trial eventを呼び出す
 		//---------------------------------------------------------------------------
 		enterTrial: function() {
-			if (this.trialpos[this.trialpos.length - 1] + 1 === this.position) {
+			if (
+				this.trailpos.length > 0 &&
+				this.trialpos[this.trialpos.length - 1] + 1 === this.position
+			) {
 				return;
 			}
 			this.newOperation();


### PR DESCRIPTION
This aims to streamline the button area below the puzzle grid.

Current state:
- move the answer and aux mark clearing button to a new menu
- add undo-all/redo-all buttons instead (and always show them, so no more moving buttons when starting trial mode)
- only one "reject trial" button; label trial buttons with current trial level

Issue right now: "Accept" seems to imply accepting only the top trial level (and I'm not convinced that would make sense); instead it accepts the whole thing as it used to.