### PR TITLE
Trialmarker

### DIFF
--- a/src-ui/js/ui/Event.js
+++ b/src-ui/js/ui/Event.js
@@ -62,17 +62,6 @@ ui.event = {
 
 		// onunloadイベントを割り当てる
 		this.addEvent(window, "unload", this, this.onunload_func);
-
-		// エラー表示を消去する
-		this.addEvent(
-			document.getElementById("quesboard"),
-			"mousedown",
-			this,
-			function(e) {
-				ui.puzzle.errclear();
-				e.stopPropagation();
-			}
-		);
 	},
 
 	//---------------------------------------------------------------------------

--- a/src-ui/p.html
+++ b/src-ui/p.html
@@ -57,6 +57,7 @@
      <li class="check" data-config="dispqnumbg"><span>__問題背景描画__Paint background of clue circles__</span></li>
      <li class="check" data-config="undefcell"><span>__未確定領域背景描画__Paint uninputted cells__</span></li>
      <li class="check" data-config="cursor"><span>__カーソルの表示__Show cursor__</span></li>
+     <li class="check" data-config="trialmarker"><span>__(please translate) Show trial markers__Show trial markers__</li>
      <li class="check" data-config="adjsize"><span>__自動横幅調節__Auto size adjust__</span></li>
      <li class="check" data-config="fullwidth"><span>__横幅最大拡張__Expand canvas width__</span></li>
      <hr>

--- a/src/puzzle/Config.js
+++ b/src/puzzle/Config.js
@@ -23,6 +23,7 @@
 				option: [1, 2]
 			}); /* 文字の描画 1:ゴシック 2:明朝 */
 			this.add("cursor", true); /* カーソルの表示 */
+			this.add("trialmarker", true); /* show trial marker */
 			this.add("irowake", false, { variety: true }); /* 線の色分け */
 			this.add("irowakeblk", false, { variety: true }); /* 黒マスの色分け */
 
@@ -387,6 +388,7 @@
 				case "irowakeblk":
 				case "dispmove":
 				case "cursor":
+				case "trialmarker":
 				case "undefcell":
 				case "autocmp":
 				case "autoerr":

--- a/src/puzzle/Graphic.js
+++ b/src/puzzle/Graphic.js
@@ -103,6 +103,7 @@
 			// 入力ターゲットの色
 			targetColorEdit: "rgb(255, 64,  64)",
 			targetColorPlay: "rgb(64,  64, 255)",
+			targetColorTrial: "rgb(255,  64, 255)",
 			ttcolor: "rgb(127,255,127)", // ques=51の入力ターゲット(TargetTriangle)
 
 			movecolor: "red",

--- a/src/puzzle/Graphic.js
+++ b/src/puzzle/Graphic.js
@@ -444,21 +444,26 @@
 				} else if (!this.useBuffer) {
 					this.setRangeObject(x1, y1, x2, y2);
 					this.flushCanvas();
-					this.paint();
+					this.paintMain();
 				} else {
 					var g = this.context,
 						g2 = this.subcontext;
 					this.context = g2;
 					this.setRangeObject(x1 - 1, y1 - 1, x2 + 1, y2 + 1);
 					this.flushCanvas();
-					this.paint();
+					this.paintMain();
 					this.context = g;
 					this.copyBufferData(g, g2, x1, y1, x2, y2);
 				}
 
 				this.resetRange();
 			},
+			paintMain: function() {
+				this.paint();
+				this.paintPost();
+			},
 			paint: function() {}, //オーバーライド用
+			paintPost: function() {},
 
 			setRange: function(x1, y1, x2, y2) {
 				if (this.range.x1 > x1) {

--- a/src/puzzle/Graphic.js
+++ b/src/puzzle/Graphic.js
@@ -101,8 +101,8 @@
 			bbcolor: "rgb(160, 160, 160)",
 
 			// 入力ターゲットの色
-			targetColor1: "rgb(255, 64,  64)",
-			targetColor3: "rgb(64,  64, 255)",
+			targetColorEdit: "rgb(255, 64,  64)",
+			targetColorPlay: "rgb(64,  64, 255)",
 			ttcolor: "rgb(127,255,127)", // ques=51の入力ターゲット(TargetTriangle)
 
 			movecolor: "red",

--- a/src/puzzle/KeyInput.js
+++ b/src/puzzle/KeyInput.js
@@ -214,6 +214,7 @@ pzpr.classmgr.makeCommon({
 
 			if (this.keydown && !this.isZ) {
 				puzzle.errclear();
+				puzzle.opemgr.updateStarts();
 			}
 
 			puzzle.emit("key", c);

--- a/src/puzzle/MouseInput.js
+++ b/src/puzzle/MouseInput.js
@@ -234,13 +234,14 @@ pzpr.classmgr.makeCommon({
 			this.mousestart = step === 0;
 			this.mousemove = step === 1;
 			this.mouseend = step === 2;
-
 			var puzzle = this.puzzle;
+
 			puzzle.emit("mouse");
 			if (!this.cancelEvent && (this.btn === "left" || this.btn === "right")) {
 				if (this.mousestart) {
 					puzzle.opemgr.newOperation();
 					puzzle.errclear();
+					puzzle.opemgr.updateStarts();
 				} else {
 					puzzle.opemgr.newChain();
 				}

--- a/src/variety-common/Graphic.js
+++ b/src/variety-common/Graphic.js
@@ -1815,16 +1815,20 @@ pzpr.classmgr.makeCommon({
 		},
 
 		drawCursor: function(islarge, isdraw) {
-			var g = this.vinc("target_cursor", "crispEdges");
+			this.drawRawCursor(
+				"target_cursor",
+				"",
+				this.puzzle.cursor,
+				islarge,
+				isdraw !== false && this.puzzle.getConfig("cursor"),
+				this.puzzle.editmode ? this.targetColorEdit : this.targetColorPlay
+			);
+		},
 
-			var d = this.range,
-				cursor = this.puzzle.cursor;
-			if (cursor.bx < d.x1 - 1 || d.x2 + 1 < cursor.bx) {
-				return;
-			}
-			if (cursor.by < d.y1 - 1 || d.y2 + 1 < cursor.by) {
-				return;
-			}
+		},
+
+		drawRawCursor: function(layerid, prefix, cursor, islarge, isdraw, color) {
+			var g = this.vinc(layerid, "crispEdges");
 
 			var px = cursor.bx * this.bw,
 				py = cursor.by * this.bh,
@@ -1838,33 +1842,28 @@ pzpr.classmgr.makeCommon({
 				size = this.bw * 0.56;
 			}
 
-			isdraw =
-				isdraw !== false &&
-				this.puzzle.getConfig("cursor") &&
-				!this.outputImage;
-			g.fillStyle = this.puzzle.editmode
-				? this.targetColorEdit
-				: this.targetColorPlay;
+			isdraw = isdraw !== false && !this.outputImage;
+			g.fillStyle = color;
 
-			g.vid = "ti1_";
+			g.vid = prefix + "ti1_";
 			if (isdraw) {
 				g.fillRect(px - size, py - size, size * 2, w);
 			} else {
 				g.vhide();
 			}
-			g.vid = "ti2_";
+			g.vid = prefix + "ti2_";
 			if (isdraw) {
 				g.fillRect(px - size, py - size, w, size * 2);
 			} else {
 				g.vhide();
 			}
-			g.vid = "ti3_";
+			g.vid = prefix + "ti3_";
 			if (isdraw) {
 				g.fillRect(px - size, py + size - w, size * 2, w);
 			} else {
 				g.vhide();
 			}
-			g.vid = "ti4_";
+			g.vid = prefix + "ti4_";
 			if (isdraw) {
 				g.fillRect(px + size - w, py - size, w, size * 2);
 			} else {

--- a/src/variety-common/Graphic.js
+++ b/src/variety-common/Graphic.js
@@ -1843,8 +1843,8 @@ pzpr.classmgr.makeCommon({
 				this.puzzle.getConfig("cursor") &&
 				!this.outputImage;
 			g.fillStyle = this.puzzle.editmode
-				? this.targetColor1
-				: this.targetColor3;
+				? this.targetColorEdit
+				: this.targetColorPlay;
 
 			g.vid = "ti1_";
 			if (isdraw) {

--- a/src/variety-common/Graphic.js
+++ b/src/variety-common/Graphic.js
@@ -1838,7 +1838,7 @@ pzpr.classmgr.makeCommon({
 					"trial_" + i,
 					piece,
 					false,
-					!piece.isnull,
+					!piece.isnull && this.puzzle.getConfig("trialmarker"),
 					this.targetColorTrial
 				);
 			}

--- a/src/variety-common/Graphic.js
+++ b/src/variety-common/Graphic.js
@@ -3,6 +3,10 @@
 pzpr.classmgr.makeCommon({
 	//---------------------------------------------------------
 	Graphic: {
+		paintPost: function() {
+			this.drawTrialStarts();
+		},
+
 		//---------------------------------------------------------------------------
 		// pc.drawQuesCells()    Cellの、境界線の上に描画される問題の黒マスをCanvasに書き込む
 		// pc.getQuesCellColor() 問題の黒マスの設定・描画判定する

--- a/src/variety-common/Graphic.js
+++ b/src/variety-common/Graphic.js
@@ -1825,6 +1825,19 @@ pzpr.classmgr.makeCommon({
 			);
 		},
 
+		drawTrialStarts: function() {
+			var starts = this.puzzle.opemgr.savedStarts;
+			for (var i = 0; i < starts.length; i++) {
+				var piece = starts[i];
+				this.drawRawCursor(
+					"trial_cursor",
+					"trial_" + i,
+					piece,
+					false,
+					!piece.isnull,
+					this.targetColorTrial
+				);
+			}
 		},
 
 		drawRawCursor: function(layerid, prefix, cursor, islarge, isdraw, color) {

--- a/src/variety/easyasabc.js
+++ b/src/variety/easyasabc.js
@@ -414,7 +414,7 @@
 			g.vid = "ti";
 			if (isdraw) {
 				var rect = bd.indicator.rect;
-				g.strokeStyle = this.targetColor1;
+				g.strokeStyle = this.targetColorEdit;
 				g.lineWidth = Math.max(this.cw / 16, 2) | 0;
 				g.strokeRect(
 					rect.bx1 * this.bw,

--- a/src/variety/starbattle.js
+++ b/src/variety/starbattle.js
@@ -475,7 +475,7 @@
 				g.vid = "ti";
 				if (isdraw) {
 					var rect = bd.starCount.rect;
-					g.strokeStyle = this.targetColor1;
+					g.strokeStyle = this.targetColorEdit;
 					g.lineWidth = Math.max(this.cw / 16, 2) | 0;
 					g.strokeRect(
 						rect.bx1 * this.bw,


### PR DESCRIPTION
Experimental feature to mark the beginning of a trial. Presently, when rejecting a trial it marks the position of the start of the trial. It would be nicer to instead draw the start of the trial differently right away and keep it visible.