### PR TITLE
Kurotto: Mark unspecified givens as satisfied

### DIFF
--- a/src/variety/kurotto.js
+++ b/src/variety/kurotto.js
@@ -114,7 +114,10 @@
 		},
 
 		getCircleFillColor: function(cell) {
-			if (this.puzzle.execConfig("autocmp") && cell.isValidNum()) {
+			if (
+				this.puzzle.execConfig("autocmp") &&
+				(cell.qnum === -2 || cell.isValidNum())
+			) {
 				return cell.checkComplete() ? this.qcmpcolor : this.circlebasecolor;
 			}
 			return null;


### PR DESCRIPTION
This is a minor annoyance, but it always bugged me that circles without an explicit numeric clue would never go grey while solving a Kurotto (to indicate that they have been satisfied, as it does with the numeric clues). This change should ensure that they are marked as grey at all times (because they can indeed never be unsatisfied).