### PR TITLE
Juosan: Mark vertical bars in nonstrict majorities

### DIFF
--- a/src/variety/juosan.js
+++ b/src/variety/juosan.js
@@ -271,7 +271,7 @@
 				if (this.checkOnly) {
 					break;
 				}
-				if (vcount > hcount) {
+				if (vcount >= hcount) {
 					clist
 						.filter(function(cell) {
 							return cell.qans === 12;


### PR DESCRIPTION
I think vertical bars are easier to count, so I chose this as the default (but it is otherwise entirely arbitrary).