### PR TITLE
Dashed grids with crosses

### DIFF
--- a/src/variety-common/Graphic.js
+++ b/src/variety-common/Graphic.js
@@ -2036,8 +2036,16 @@ pzpr.classmgr.makeCommon({
 			x2 += ~x2 & 1;
 			y2 += ~y2 & 1; /* (x1,y1)-(x2,y2)を外側の奇数範囲まで広げる */
 
-			var dotCount = Math.max(this.cw / (this.cw / 10 + 3), 1) | 0;
-			var dotSize = this.cw / (dotCount * 2);
+			var dotPrecount = Math.max(this.cw / 5, 1);
+			var dotCount = Math.round(dotPrecount / 2) * 2 + 0.8;
+			var dotSize = this.cw / dotCount;
+
+			var dasharray = [dotSize * 0.9];
+			for(var i = 0; i < dotCount - 2; i++){
+				dasharray.push(dotSize);
+			}
+			dasharray.push(dotSize * 0.9);
+			dasharray.push(0);
 
 			g.lineWidth = 1;
 			g.strokeStyle = this.gridcolor;
@@ -2046,14 +2054,14 @@ pzpr.classmgr.makeCommon({
 					py1 = y1 * this.bh,
 					py2 = y2 * this.bh;
 				g.vid = "cliney_" + i;
-				g.strokeDashedLine(px, py1, px, py2, [dotSize]);
+				g.strokeDashedLine(px, py1, px, py2, dasharray);
 			}
 			for (var i = y1; i <= y2; i += 2) {
 				var py = i * this.bh,
 					px1 = x1 * this.bw,
 					px2 = x2 * this.bw;
 				g.vid = "clinex_" + i;
-				g.strokeDashedLine(px1, py, px2, py, [dotSize]);
+				g.strokeDashedLine(px1, py, px2, py, dasharray);
 			}
 		},
 

--- a/src/variety-common/Graphic.js
+++ b/src/variety-common/Graphic.js
@@ -2160,8 +2160,16 @@ pzpr.classmgr.makeCommon({
 			x2 += x2 & 1;
 			y2 += y2 & 1; /* (x1,y1)-(x2,y2)を外側の偶数範囲に移動する */
 
-			var dotCount = Math.max(this.cw / (this.cw / 10 + 3), 1) | 0;
-			var dotSize = this.cw / (dotCount * 2);
+			var dotPrecount = Math.max(this.cw / 5, 1);
+			var dotCount = Math.round(dotPrecount / 2) * 2 + 0.8;
+			var dotSize = this.cw / dotCount;
+
+			var dasharray = [dotSize * 0.9];
+			for(var i = 0; i < dotCount - 2; i++){
+				dasharray.push(dotSize);
+			}
+			dasharray.push(dotSize * 0.9);
+			dasharray.push(0);
 
 			var bs = haschassis !== false ? 2 : 0,
 				bw = this.bw,
@@ -2178,14 +2186,14 @@ pzpr.classmgr.makeCommon({
 					py1 = y1 * bh,
 					py2 = y2 * bh;
 				g.vid = "bdy_" + i;
-				g.strokeDashedLine(px, py1, px, py2, [dotSize]);
+				g.strokeDashedLine(px, py1, px, py2, dasharray);
 			}
 			for (var i = ya; i <= yb; i += 2) {
 				var py = i * bh,
 					px1 = x1 * bw,
 					px2 = x2 * bw;
 				g.vid = "bdx_" + i;
-				g.strokeDashedLine(px1, py, px2, py, [dotSize]);
+				g.strokeDashedLine(px1, py, px2, py, dasharray);
 			}
 		},
 

--- a/src/variety-common/Graphic.js
+++ b/src/variety-common/Graphic.js
@@ -2041,7 +2041,7 @@ pzpr.classmgr.makeCommon({
 			var dotSize = this.cw / dotCount;
 
 			var dasharray = [dotSize * 0.9];
-			for(var i = 0; i < dotCount - 2; i++){
+			for (var i = 0; i < dotCount - 2; i++) {
 				dasharray.push(dotSize);
 			}
 			dasharray.push(dotSize * 0.9);
@@ -2173,7 +2173,7 @@ pzpr.classmgr.makeCommon({
 			var dotSize = this.cw / dotCount;
 
 			var dasharray = [dotSize * 0.9];
-			for(var i = 0; i < dotCount - 2; i++){
+			for (var i = 0; i < dotCount - 2; i++) {
 				dasharray.push(dotSize);
 			}
 			dasharray.push(dotSize * 0.9);

--- a/src/variety/nawabari.js
+++ b/src/variety/nawabari.js
@@ -234,7 +234,7 @@
 			var dotSize = this.cw / dotCount;
 
 			var dasharray = [dotSize * 0.9];
-			for(var i = 0; i < dotCount - 2; i++){
+			for (var i = 0; i < dotCount - 2; i++) {
 				dasharray.push(dotSize);
 			}
 			dasharray.push(dotSize * 0.9);

--- a/src/variety/nawabari.js
+++ b/src/variety/nawabari.js
@@ -229,9 +229,16 @@
 		drawValidDashedGrid: function() {
 			var g = this.vinc("grid_waritai", "crispEdges", true);
 
-			var dotmax = this.cw / 10 + 3;
-			var dotCount = Math.max(this.cw / dotmax, 1);
-			var dotSize = this.cw / (dotCount * 2);
+			var dotPrecount = Math.max(this.cw / 5, 1);
+			var dotCount = Math.round(dotPrecount / 2) * 2 + 0.8;
+			var dotSize = this.cw / dotCount;
+
+			var dasharray = [dotSize * 0.9];
+			for(var i = 0; i < dotCount - 2; i++){
+				dasharray.push(dotSize);
+			}
+			dasharray.push(dotSize * 0.9);
+			dasharray.push(0);
 
 			g.lineWidth = 1;
 			g.strokeStyle = this.gridcolor;
@@ -244,9 +251,9 @@
 					var px = border.bx * this.bw,
 						py = border.by * this.bh;
 					if (border.isVert()) {
-						g.strokeDashedLine(px, py - this.bh, px, py + this.bh, [dotSize]);
+						g.strokeDashedLine(px, py - this.bh, px, py + this.bh, dasharray);
 					} else {
-						g.strokeDashedLine(px - this.bw, py, px + this.bw, py, [dotSize]);
+						g.strokeDashedLine(px - this.bw, py, px + this.bw, py, dasharray);
 					}
 				} else {
 					g.vhide();


### PR DESCRIPTION
Weird blurry lines sometimes on Mac when rendering to a non-Retina display. (seems fixed giving the dashed lines `shape-rendering: geometricPrecision`)