### PR TITLE
doppel-block, maxi-loop, curve-data, renban: translate some msgs

### DIFF
--- a/src-ui/js/ui/ToolArea.js
+++ b/src-ui/js/ui/ToolArea.js
@@ -196,9 +196,9 @@ ui.toolarea = {
 		if (idname === "variant") {
 			var str;
 			if (ui.menuconfig.get("variant")) {
-				str = ui.selectStr("チェック", "Check base type");
+				str = ui.selectStr("本家ルールでチェック", "Check base type");
 			} else {
-				str = ui.selectStr("チェック", "Check"); /* please translate */
+				str = ui.selectStr("チェック", "Check");
 			}
 			getEL("btncheck").textContent = str;
 		}

--- a/src-ui/p.html
+++ b/src-ui/p.html
@@ -138,7 +138,7 @@
       <div class="child" data-value="crossdot">__黒点__Shaded dots__</div>
       <div class="child" data-value="ineq">__不等号__Inequality marks__</div>
       <div class="child" data-value="move-clue">__図形の移動__Move clue__</div>
-      <div class="child" data-value="copy-answer">__(please translate) Copy answer__Copy answer__</div>
+      <div class="child" data-value="copy-answer">__解答モードから記号作成__Copy answer__</div>
       <div class="child" data-value="mark-circle">__丸記号__Circles__</div>
       <div class="child" data-value="mark-triangle">__三角形__Triangles__</div>
       <div class="child" data-value="mark-rect">__四角形__Rectangles__</div>
@@ -288,7 +288,7 @@
     <div class="config" data-config="dontpassallcell">
       <label>
         <input type="checkbox">
-        <span>__(please translate) Lines need not pass all crossings__Lines need not pass all crossings__</span>
+        <span>__線が全ての交差点を通過していない場合も正解とする__Lines need not pass all crossings__</span>
       </label>
     </div>
     <div class="config" data-config="aquarium_regions">
@@ -568,7 +568,7 @@
           <div><span>__入力モード__Input Mode__</span> | </div>
           <div>
             <div class="child" data-value="auto">__自動__Auto__</div>
-            <div class="child" data-value="slide">__(please translate) Slide__Slide__</div>
+            <div class="child" data-value="slide">__平行移動__Slide__</div>
           </div>
         </div>
       </div>

--- a/src/variety/country.js
+++ b/src/variety/country.js
@@ -1057,11 +1057,11 @@
 	},
 	"FailCode@maxi": {
 		blLineShort: [
-			"(Please translate) All lines in a room are shorter than the number.",
+			"枠内のどの線も、連続して通るマス数が数字よりも小さいです。",
 			"All lines in a room are shorter than the number."
 		],
 		blLineLong: [
-			"(Please translate) A line in a room is longer than the number.",
+			"枠内を連続して通るマス数が、数字よりも大きい線があります。",
 			"A line in a room is longer than the number."
 		]
 	}

--- a/src/variety/doppelblock.js
+++ b/src/variety/doppelblock.js
@@ -374,11 +374,11 @@
 
 	FailCode: {
 		nmSum: [
-			"(please translate) The sum of the numbers between the two blocks is wrong.",
+			"黒マスに挟まれた数字の和と、枠外の数字が一致していません。",
 			"The sum of the numbers between the two blocks is wrong."
 		],
 		ceTooManyBlocks: [
-			"(please translate) There are more than two blocks.",
+			"3つ以上の黒マスがある行または列があります。",
 			"There are more than two blocks in a row."
 		]
 	}

--- a/src/variety/renban.js
+++ b/src/variety/renban.js
@@ -252,7 +252,7 @@
 			"A room has two or more equal numbers."
 		],
 		bkNotSeqNum: [
-			"部屋に入る数字が正しくありません。", // outdated, please translate
+			"数字が連番になっていない部屋があります。",
 			"The numbers in the room are not consecutive."
 		],
 		cbDiffLenNe: [


### PR DESCRIPTION
Thank you for answering my questions in #15 !

This time, I have translated into japanese for doppel-block, renban and maxi-loop in addition to some messages related to my questions.

About line 199 in  src-ui/js/ui/ToolArea.js, the new sentence I suggest may be too long. If there is a problem to display this word, I will re-translate it.

