### PR TITLE
Paint chassis towards the outside

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -40,6 +40,7 @@
 * doubleback: Save empty cells to file.
 * kurochute: Fix error highlighting.
 * renban: Fix consecutive number error check.
+* shakashaka: Fix alignment of triangles to shaded cells.
 * triplace: Don't allow drawing on clues.
 * walllogic: Fix redraw with autocompletion.
 * yajilin: Fix interaction between edit mode and answer.

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -24,7 +24,7 @@
 |`use_tri`|`number`|`1`|Input method for triangles from mouse for `'Shakashaka'` <br> Possible value: `1, 2 or 3`|
 |`support_tri`|`boolean`|`true`|Enable to support inputting triangles next to two or more walls for `'Shakashaka'`|
 |`bgcolor`|`boolean`|`false`|Enable to input background color for `'Slitherlink'`|
-|`singlenum`|`boolean`|`true`|Disable to input plural answer numbers in a room for `'Hanare-gumi'`|
+|`singlenum`|`boolean`|`true`|Disable to input multiple answer numbers in a room for `'Hanare-gumi'`|
 |`enline`|`boolean`|`true`|Limit to input segments only between points for `'Kouchoku'`|
 |`lattice`|`boolean`|`true`|Restrict not to input segments if other points are on the lattice for `'Kouchoku'`|
 
@@ -34,7 +34,7 @@
 |---|---|---|---|
 |`autocmp`|`boolean`|`true`|Show complete numbers apart from incompleted one automatically.|
 |`autoerr`|`boolean`|`false`|Show incomplete/wrong numbers automatically.|
-|`multierr`|`boolean`|`false`|Check plural errors in `puzzle.check()` API.|
+|`multierr`|`boolean`|`false`|Check multiple errors in `puzzle.check()` API.|
 |`forceallcell`|`boolean`|`false`|Force all cells to have number to get completed for `'fillomino'`|
 |`passallcell`|`boolean`|`true`|Force all cells to be passed for `'arukone'`|
 

--- a/docs/Puzzle.md
+++ b/docs/Puzzle.md
@@ -187,4 +187,4 @@ For details, see [list of puzzle config document](Config.md).
 |`autocmp_area`|`boolean`|`false`|Paint background of completed blocks/areas automatically.|
 |`autocmp_border`|`boolean`|`false`|Paint borders between different blocks/areas automatically.|
 |`autoerr`|`boolean`|`false`|Show incomplete/wrong numbers automatically.|
-|`multierr`|`boolean`|`false`|Check plural errors in `puzzle.check()` API.|
+|`multierr`|`boolean`|`false`|Check multiple errors in `puzzle.check()` API.|

--- a/src-ui/js/ui/Event.js
+++ b/src-ui/js/ui/Event.js
@@ -73,6 +73,11 @@ ui.event = {
 
 		// onunloadイベントを割り当てる
 		this.addEvent(window, "unload", this, this.onunload_func);
+
+		if (!!matchMedia) {
+			var mqString = "(resolution: 1dppx)";
+			matchMedia(mqString).addListener(this.onpixelratiochange_func);
+		}
 	},
 
 	setDocumentEvents: function() {
@@ -145,5 +150,9 @@ ui.event = {
 				this.visibilityCallbacks = [];
 			}
 		}
+	},
+
+	onpixelratiochange_func: function(e) {
+		ui.puzzle.redraw(true);
 	}
 };

--- a/src-ui/js/ui/MenuArea.js
+++ b/src-ui/js/ui/MenuArea.js
@@ -353,9 +353,6 @@ ui.menuarea = {
 		ui.menuconfig.set("toolarea", !ui.menuconfig.get("toolarea"));
 		ui.displayAll();
 	},
-	repaint: function() {
-		ui.puzzle.redraw(true);
-	},
 	disppopup: function(e) {
 		var el = e.target;
 		if (el.nodeName === "SPAN") {

--- a/src/puzzle/Graphic.js
+++ b/src/puzzle/Graphic.js
@@ -296,7 +296,9 @@
 				var cw = (cwid / cols) | 0,
 					ch = (chgt / rows) | 0;
 
-				this.devicePixelRatio = window.devicePixelRatio || 1;
+				this.devicePixelRatio = this.puzzle.pzpr.env.browser
+					? window.devicePixelRatio || 1
+					: 1;
 
 				if (this.puzzle.getConfig("squarecell")) {
 					this.cw = this.ch = Math.min(cw, ch);

--- a/src/puzzle/Graphic.js
+++ b/src/puzzle/Graphic.js
@@ -317,8 +317,9 @@
 				var gwdev = Math.max(1, Math.round(gw / pxSize));
 				this.gw = gwdev * pxSize;
 
-				var lwmin = this.lwmin / this.devicePixelRatio;
-				this.lw = Math.max(this.cw / this.lwratio, lwmin);
+				var lw = Math.max(this.cw / this.lwratio, this.lwmin);
+				var lwdev = Math.max(1, Math.round(lw / pxSize));
+				this.lw = lwdev * pxSize;
 				this.lm = this.lw / 2;
 			},
 			setOffset: function() {

--- a/src/puzzle/Graphic.js
+++ b/src/puzzle/Graphic.js
@@ -149,6 +149,8 @@
 			bw: 18, // セルの横幅/2
 			bh: 18, // セルの縦幅/2
 
+			devicePixelRatio: 1,
+			gw: 1, // grid width
 			lw: 1, // LineWidth 境界線・Lineの太さ
 			lwmin: 3,
 			lm: 1, // LineMargin
@@ -294,6 +296,8 @@
 				var cw = (cwid / cols) | 0,
 					ch = (chgt / rows) | 0;
 
+				this.devicePixelRatio = window.devicePixelRatio || 1;
+
 				if (this.puzzle.getConfig("squarecell")) {
 					this.cw = this.ch = Math.min(cw, ch);
 				} else {
@@ -304,7 +308,15 @@
 				this.bw = this.cw / 2;
 				this.bh = this.ch / 2;
 
-				this.lw = Math.max(this.cw / this.lwratio, this.lwmin);
+				var gwmax = 1,
+					gwratio = 40;
+				var gw = Math.min(this.cw / gwratio, gwmax);
+				var pxSize = 1 / this.devicePixelRatio;
+				var gwdev = Math.max(1, Math.round(gw / pxSize));
+				this.gw = gwdev * pxSize;
+
+				var lwmin = this.lwmin / this.devicePixelRatio;
+				this.lw = Math.max(this.cw / this.lwratio, lwmin);
 				this.lm = this.lw / 2;
 			},
 			setOffset: function() {

--- a/src/variety-common/Graphic.js
+++ b/src/variety-common/Graphic.js
@@ -2232,20 +2232,20 @@ pzpr.classmgr.makeCommon({
 			var boardWidth = bd.cols * this.cw,
 				boardHeight = bd.rows * this.ch;
 			var lw = this.lw,
-				lm = this.lm;
+				lm = this.lw - this.gw;
 			if (this.pid === "bosanowa") {
 				lw = 1;
 				lm = 0.5;
 			}
 			g.fillStyle = this.quescolor;
 			g.vid = "chs1_";
-			g.fillRect(-lm, -lm, lw, boardHeight + lw);
+			g.fillRect(-lm, -lm, lw, boardHeight + 2 * lm);
 			g.vid = "chs2_";
-			g.fillRect(boardWidth - lm, -lm, lw, boardHeight + lw);
+			g.fillRect(boardWidth + lm, -lm, -lw, boardHeight + 2 * lm);
 			g.vid = "chs3_";
-			g.fillRect(-lm, -lm, boardWidth + lw, lw);
+			g.fillRect(-lm, -lm, boardWidth + 2 * lm, lw);
 			g.vid = "chs4_";
-			g.fillRect(-lm, boardHeight - lm, boardWidth + lw, lw);
+			g.fillRect(-lm, boardHeight + lm, boardWidth + 2 * lm, -lw);
 		},
 		drawChassis_ex1: function(boldflag) {
 			var g = this.vinc("chassis_ex1", "crispEdges", true),

--- a/src/variety-common/Graphic.js
+++ b/src/variety-common/Graphic.js
@@ -2057,7 +2057,7 @@ pzpr.classmgr.makeCommon({
 		},
 
 		getDashArray: function() {
-			var dashCount = Math.max(Math.round(this.cw / 10), 3);
+			var dashCount = Math.max(Math.round(this.cw / 10), 4);
 			var stepSize = this.cw / dashCount;
 			var lengthOn = (5 / 8) * stepSize;
 			var lengthOff = stepSize - lengthOn;

--- a/src/variety-common/Graphic.js
+++ b/src/variety-common/Graphic.js
@@ -1327,7 +1327,7 @@ pzpr.classmgr.makeCommon({
 		},
 		drawTriangle1: function(px, py, num) {
 			var g = this.context;
-			var mgn = this.pid === "reflect" ? 1 : 0,
+			var mgn = this.pid === "reflect" ? 1 : 0.5,
 				bw = this.bw + 1 - mgn,
 				bh = this.bh + 1 - mgn;
 			g.beginPath();

--- a/src/variety-common/Graphic.js
+++ b/src/variety-common/Graphic.js
@@ -1306,7 +1306,7 @@ pzpr.classmgr.makeCommon({
 		// pc.drawTriangle1()  三角形をCanvasに書き込む(1マスのみ)
 		//---------------------------------------------------------------------------
 		drawTriangle: function() {
-			var g = this.vinc("cell_triangle", "auto");
+			var g = this.vinc("cell_triangle", "crispEdges");
 
 			var clist = this.range.cells;
 			for (var i = 0; i < clist.length; i++) {

--- a/src/variety-common/Graphic.js
+++ b/src/variety-common/Graphic.js
@@ -2118,7 +2118,7 @@ pzpr.classmgr.makeCommon({
 				yb = Math.min(y2, maxy - bs);
 
 			// isdraw!==false: 指定無しかtrueのときは描画する
-			g.lineWidth = 1;
+			g.lineWidth = this.gw;
 			g.strokeStyle = this.gridcolor;
 			for (var i = xa; i <= xb; i += 2) {
 				g.vid = "bdy_" + i;
@@ -2185,7 +2185,7 @@ pzpr.classmgr.makeCommon({
 			var ya = Math.max(y1, miny + bs),
 				yb = Math.min(y2, maxy - bs);
 
-			g.lineWidth = 1;
+			g.lineWidth = this.gw;
 			g.strokeStyle = this.gridcolor;
 			for (var i = xa; i <= xb; i += 2) {
 				var px = i * bw,

--- a/src/variety/country.js
+++ b/src/variety/country.js
@@ -1034,24 +1034,24 @@
 	"FailCode@onsen": {
 		blPassTwice: [
 			"ある線が１つの部屋を２回以上通っています。",
-			"A line passes a room twice or more."
+			"A line passes a room more than once."
 		],
 		blLineNe: [
 			"線が通過するマスの数が数字と違います。",
-			"The Length of the path in a room is different from the number of the loop."
+			"The length of the path in a room is different from the number of the loop."
 		],
 		blLineDiff: [
 			"各部屋で線が通過するマスの数が違います。",
-			"The Length of the path in a room is different in each room."
+			"The length of the path in a room is different in some rooms."
 		],
 		bkNoLine: ["線の通っていない部屋があります。", "A room remains blank."],
 		lnIsolate: [
 			"線の通っていない○があります。",
-			"Lines doesn't pass a circle."
+			"A circle doesn't have a line."
 		],
 		lpNumGt2: [
 			"数字が2つ以上含まれたループがあります。",
-			"A loop has plural numbers."
+			"A loop has more than one number."
 		],
 		lpNoNum: ["○を含んでいないループがあります。", "A loop has no numbers."]
 	},

--- a/src/variety/fillmat.js
+++ b/src/variety/fillmat.js
@@ -178,23 +178,23 @@
 		],
 		bkNumGe2: [
 			"1つのタタミに2つ以上の数字が入っています。",
-			"A tatami has plural numbers."
+			"A tatami has more than one number."
 		],
 		bkSizeNe: [
 			"数字とタタミの大きさが違います。",
-			"The size of tatami and the number written in Tatami is different."
+			"The number is different from the size of the tatami."
 		],
 		bkSizeEq: [
 			"数字とタタミの大きさが同じです。",
-			"The size of tatami and the number is the same."
+			"The number is equal to the size of the tatami."
 		],
 		bkLenGt4: [
 			"「幅１マス、長さ１～４マス」ではないタタミがあります。",
-			"The width of Tatami is over 1 or the length is over 4."
+			"The width of the tatami is more than one, or the length is more than four."
 		],
 		bsSizeEq: [
 			"隣り合うタタミの大きさが同じです。",
-			"The same size Tatami are adjacent."
+			"Tatamis of the same size are adjacent."
 		]
 	}
 });

--- a/src/variety/hakoiri.js
+++ b/src/variety/hakoiri.js
@@ -316,23 +316,23 @@
 	FailCode: {
 		bkDupNum: [
 			"1つのハコに同じ記号が複数入っています。",
-			"A box has same plural marks."
+			"A box has duplicate shapes."
 		],
 		bkNumGt3: [
 			"1つのハコに4つ以上の記号が入っています。",
-			"A box has four or more marks."
+			"A box has more than three shapes."
 		],
 		bkNumLt3: [
 			"1つのハコに2つ以下の記号しか入っていません。",
-			"A box has tow or less marks."
+			"A box has less than three shapes."
 		],
 		nmDivide: [
 			"タテヨコにつながっていない記号があります。",
-			"Marks are divided."
+			"The shapes are divided."
 		],
 		nmAround: [
 			"同じ記号がタテヨコナナメに隣接しています。",
-			"Same marks are adjacent."
+			"Equal shapes touch."
 		]
 	}
 });

--- a/src/variety/hanare.js
+++ b/src/variety/hanare.js
@@ -273,7 +273,7 @@
 		bkNoNum: ["数字の入っていない部屋があります。", "A room has no numbers."],
 		bkNumGe2: [
 			"1つの部屋に2つ以上の数字が入っています。",
-			"A room has plural numbers."
+			"A room has more than one number."
 		],
 		bkSizeNe: [
 			"数字と部屋の大きさが違います。",
@@ -281,7 +281,7 @@
 		],
 		nmDiffDistNe: [
 			"２つの数字の差とその間隔が正しくありません。",
-			"The distance of the paired numbers is not equal to the diff of them."
+			"The distance of the paired numbers is not equal to their difference."
 		]
 	}
 });

--- a/src/variety/hebi.js
+++ b/src/variety/hebi.js
@@ -502,15 +502,15 @@
 	},
 
 	FailCode: {
-		bkDupNum: ["同じ数字が入っています。", "A Snake has same plural marks."],
+		bkDupNum: ["同じ数字が入っています。", "A snake has duplicate numbers."],
 		bkSizeNe5: [
 			"大きさが５ではない蛇がいます。",
 			"The size of a snake is not five."
 		],
-		bsSnake: ["別々の蛇が接しています。", "Other snakes are adjacent."],
+		bsSnake: ["別々の蛇が接しています。", "Different snakes are adjacent."],
 		anNumberNe: [
 			"矢印の先にある数字が正しくありません。",
-			"There is a wrong number which is in front of the arrowed number."
+			"A clue points at the wrong number."
 		],
 		snakeAttack: [
 			"蛇の視線の先に別の蛇がいます。",

--- a/src/variety/kaero.js
+++ b/src/variety/kaero.js
@@ -549,15 +549,15 @@
 	"FailCode@kaero": {
 		bkNoNum: [
 			"アルファベットのないブロックがあります。",
-			"A block has no letters."
+			"An area has no letters."
 		],
 		bkPlNum: [
 			"１つのブロックに異なるアルファベットが入っています。",
-			"A block has plural kinds of letters."
+			"An area has more than one kind of letter."
 		],
 		bkSepNum: [
 			"同じアルファベットが異なるブロックに入っています。",
-			"Same kinds of letters are placed different blocks."
+			"Letters of one kind are placed in different areas."
 		]
 	},
 	"FailCode@armyants": {
@@ -569,12 +569,14 @@
 			"線が境界線をまたいでいます。",
 			"There is a line across a border."
 		],
-		bsAnt: ["別々のアリが接しています。", "Other ants are adjacent."],
-		bkWrongNum: ["アリの数字がおかしいです。", "Numbers on the ant is wrong."],
+		bsAnt: ["別々のアリが接しています。", "Two ants are adjacent."],
+		bkWrongNum: [
+			"アリの数字がおかしいです。",
+			"The numbers on the ant are wrong."
+		],
 		ceNumGtSize: [
 			"数字がアリの大きさよりも大きいです。",
 			"A number is greater than the size of the ant."
-		],
-		nmBranch: ["アリが分岐しています。", "An ant could have branch."]
+		]
 	}
 });

--- a/src/variety/kinkonkan.js
+++ b/src/variety/kinkonkan.js
@@ -757,15 +757,15 @@
 		bkNoObj: ["斜線の引かれていない部屋があります。", "A room has no mirrors."],
 		bkObjGe2: [
 			"斜線が複数引かれた部屋があります。",
-			"A room has plural mirrors."
+			"A room has more than one mirror."
 		],
 		pairedLetterNe: [
 			"光が同じ文字の場所へ到達しません。",
-			"Beam from a light doesn't reach one's pair."
+			"Beam from a light doesn't reach its pair."
 		],
 		pairedNumberNe: [
 			"光の反射回数が正しくありません。",
-			"The count of refrection is wrong."
+			"The number of reflections is wrong."
 		]
 	}
 });

--- a/src/variety/nawabari.js
+++ b/src/variety/nawabari.js
@@ -491,7 +491,7 @@
 		bkNoNum: ["数字の入っていない部屋があります。", "A room has no numbers."],
 		bkNumGe2: [
 			"1つの部屋に2つ以上の数字が入っています。",
-			"A room has plural numbers."
+			"A room has more than one number."
 		],
 		bkSizeLt3: [
 			"サイズが3マスより小さいブロックがあります。",

--- a/src/variety/nurikabe.js
+++ b/src/variety/nurikabe.js
@@ -363,36 +363,36 @@
 		],
 		bkNumGe2: [
 			"1つのシマに2つ以上の数字が入っています。",
-			"An area of unshaded cells has plural numbers."
+			"An area of unshaded cells has more than one number."
 		],
 		bkSizeNe: [
 			"数字とシマの面積が違います。",
-			"The number is not equal to the number of the size of the area."
+			"The number is not equal to the size of the area."
 		]
 	},
 	"FailCode@nuribou": {
 		csWidthGt1: [
 			"「幅１マス、長さ１マス以上」ではない黒マスのカタマリがあります。",
-			"There is a mass of shaded cells, whose width is more than two."
+			"There is a mass of shaded cells whose width is more than two."
 		],
 		csCornerSize: [
 			"同じ面積の黒マスのカタマリが、角を共有しています。",
-			"Masses of shaded cells whose length is the same share a corner."
+			"Masses of shaded cells with the same length share a corner."
 		]
 	},
 
 	"FailCode@mochikoro,mochinyoro": {
 		cuNotRect: [
 			"四角形でない白マスのブロックがあります。",
-			"There is a block of unshaded cells that is not rectangle."
+			"There is a block of unshaded cells that is not a rectangle."
 		],
 		csRect: [
 			"四角形になっている黒マスのブロックがあります。",
-			"There is a block of shaded cells that is rectangle."
+			"There is a block of shaded cells that is a rectangle."
 		],
 		csDivide8: [
 			"孤立した白マスのブロックがあります。",
-			"Unshaded cells are divided."
+			"The unshaded cells are divided."
 		]
 	}
 });

--- a/src/variety/roma.js
+++ b/src/variety/roma.js
@@ -338,7 +338,7 @@
 	FailCode: {
 		bkDupNum: [
 			"1つの領域に2つ以上の同じ矢印が入っています。",
-			"An area has plural same arrows."
+			"An area has duplicate arrows."
 		],
 		stopHalfway: [
 			"ゴールにたどり着かないセルがあります。",

--- a/src/variety/shikaku.js
+++ b/src/variety/shikaku.js
@@ -287,20 +287,23 @@
 		bkNoNum: ["数字の入っていない領域があります。", "An area has no numbers."],
 		bkNumGe2: [
 			"1つの領域に2つ以上の数字が入っています。",
-			"An area has plural numbers."
+			"An area has more than one number."
 		],
 		bkSizeNe: [
 			"数字と領域の大きさが違います。",
 			"The size of the area is not equal to the number."
 		],
-		bkNotRect: ["四角形ではない領域があります。", "An area is not rectangle."],
+		bkNotRect: [
+			"四角形ではない領域があります。",
+			"An area is not a rectangle."
+		],
 		bkNotRect3: [
 			"大きさが3の倍数ではないのに四角形ではない領域があります。",
-			"An area whose size is not multiples of three is not rectangle."
+			"An area whose size is not a multiple of three is not a rectangle."
 		],
 		bkNotLshape3: [
 			"大きさが3の倍数である領域がL字型になっていません。",
-			"An area whose size is multiples of three is not L-shape."
+			"An area whose size is a multiple of three is not L-shaped."
 		]
 	}
 });

--- a/src/variety/shimaguni.js
+++ b/src/variety/shimaguni.js
@@ -488,11 +488,11 @@
 	"FailCode@shimaguni": {
 		bkShadeNe: [
 			"海域内の数字と国のマス数が一致していません。",
-			"The number of shaded cells is not equals to the number."
+			"The number of shaded cells is not equal to the number."
 		],
 		bkShadeDivide: [
 			"1つの海域に入る国が2つ以上に分裂しています。",
-			"Countries in one marine area are divided to plural ones."
+			"The shaded cells in a marine area are divided."
 		],
 		bkNoShade: [
 			"黒マスのカタマリがない海域があります。",
@@ -500,11 +500,11 @@
 		],
 		cbShade: [
 			"異なる海域にある国どうしが辺を共有しています。",
-			"Countries in other marine area share the side over border line."
+			"Countries in different marine areas are adjacent."
 		],
 		bsEqShade: [
 			"隣り合う海域にある国の大きさが同じです。",
-			"The size of countries that there are in adjacent marine areas are the same."
+			"The sizes of countries that are in adjacent marine areas are the same."
 		]
 	},
 
@@ -522,15 +522,15 @@
 	"FailCode@stostone": {
 		cbShade: [
 			"異なる部屋にある黒マスどうしが辺を共有しています。",
-			"Shade cell blocks in other region are adjacent over border line."
+			"Shaded cells are adjacent over a border."
 		],
 		csUpper: [
 			"ブロックを落とした後に黒マスが盤面の上半分に残っています。",
-			"Shaded cells are remained in upper half of the board after they are fallen."
+			"Shaded cells remain in the upper half of the board after the blocks have fallen."
 		],
 		cuLower: [
 			"ブロックを落とした後の空間が盤面の下半分にあります。",
-			"Unshaded cells exist in lower half of the board after blocks are fallen."
+			"Unshaded cells exist in the lower half of the board after the blocks have fallen."
 		]
 	}
 });

--- a/src/variety/tateyoko.js
+++ b/src/variety/tateyoko.js
@@ -374,10 +374,10 @@
 		},
 
 		checkBarOverNum: function() {
-			this.checkShade(1, "nmConnBarGt");
+			this.checkShade(1, "nmConnBarWrong");
 		},
 		checkBarLessNum: function() {
-			this.checkShade(2, "nmConnBarLt");
+			this.checkShade(2, "nmConnBarWrong");
 		},
 		checkShade: function(type, code) {
 			var bd = this.board;
@@ -450,17 +450,13 @@
 		ceNoBar: ["何も入っていないマスがあります。", "There is an empty cell."],
 		bkSizeNe: [
 			"数字と棒の長さが違います。",
-			"The number is different from the length of line."
+			"The number is different from the length of the line."
 		],
 		baPlNum: [
 			"1つの棒に2つ以上の数字が入っています。",
-			"A line passes plural numbers."
+			"A line passes more than one number."
 		],
-		nmConnBarGt: [
-			"黒マスに繋がる線の数が正しくありません。",
-			"The number of lines connected to a shaded cell is wrong."
-		],
-		nmConnBarLt: [
+		nmConnBarWrong: [
 			"黒マスに繋がる線の数が正しくありません。",
 			"The number of lines connected to a shaded cell is wrong."
 		]

--- a/src/variety/toichika.js
+++ b/src/variety/toichika.js
@@ -363,7 +363,7 @@
 		bkNoNum: ["国に矢印が入っていません。", "A country has no arrow."],
 		bkNumGe2: [
 			"1つの国に2つ以上の矢印が入っています。",
-			"A country has plural arrows."
+			"A country has more than one arrow."
 		],
 		arAdjPair: [
 			"辺を共有する国にペアとなる矢印が入っています。",
@@ -371,7 +371,7 @@
 		],
 		arAlone: [
 			"矢印の先にペアとなる矢印がいません。",
-			"There is not paired arrow in the direction of an arrow."
+			"There is no paired arrow in the direction of an arrow."
 		]
 	}
 });

--- a/test/script/tateyoko.js
+++ b/test/script/tateyoko.js
@@ -4,7 +4,7 @@ ui.debug.addDebugData("tateyoko", {
 	url: "5/5/i23i3ono2i25i22pnqi33i2",
 	failcheck: [
 		[
-			"nmConnBarGt",
+			"nmConnBarWrong",
 			"pzprv3/tateyoko/5/5/. . 3 . . /. e . e 2 /. . 5 . . /2 a . b . /. . 3 . . /0 0 0 0 0 /2 . 2 . 2 /0 0 0 0 0 /0 . 0 . 0 /0 0 0 0 0 /"
 		],
 		[
@@ -16,7 +16,7 @@ ui.debug.addDebugData("tateyoko", {
 			"pzprv3/tateyoko/5/5/. . 3 . . /. e . e 2 /. . 5 . . /2 a . b . /. . 3 . . /0 0 0 0 0 /0 . 0 . 0 /0 2 2 2 2 /0 . 0 . 0 /0 0 0 0 0 /"
 		],
 		[
-			"nmConnBarLt",
+			"nmConnBarWrong",
 			"pzprv3/tateyoko/5/5/. . 3 . . /. e . e 2 /. . 5 . . /2 a . b . /. . 3 . . /0 0 0 0 0 /0 . 0 . 0 /2 2 2 2 2 /0 . 0 . 0 /0 0 0 0 0 /"
 		],
 		[


### PR DESCRIPTION
Currently, the "chassis" (puzzle frame is centered on the 0th/nth grid line, but thicker than usual grid lines, which makes cells in the outer rows smaller than others. This changes it to paint them towards the outside.

Split out from #165 because there are some glitches with the current implementation. In particular, the svg viewBox cuts off a bit of the top at low cell size, due to dubious calculations involving `ui.puzzle.painter.margin`.