### PR TITLE
Network play

### DIFF
--- a/src-ui/css/ui.css
+++ b/src-ui/css/ui.css
@@ -397,7 +397,7 @@ form#fileform2 {
   height: 100px;
 }
 
-#urlanchor {
+.urlanchor {
   display: block;
   padding: 5px;
   background: white;

--- a/src-ui/js/pzpr-ui.js
+++ b/src-ui/js/pzpr-ui.js
@@ -15,6 +15,7 @@ exports.files = [
 	"ui/KeyPopup",
 	"ui/Timer",
 	"ui/AuxEditor",
+	"ui/Network",
 	"common/outro"
 ].map(function(mod) {
 	return "src-ui/js/" + mod + ".js";

--- a/src-ui/js/ui/Boot.js
+++ b/src-ui/js/ui/Boot.js
@@ -77,6 +77,10 @@
 
 		puzzle.on("request-aux-editor", ui.auxeditor.open);
 
+		if (!!onload_option.net) {
+			ui.network.configure(onload_option.net, onload_option.key);
+		}
+
 		return true;
 	}
 

--- a/src-ui/js/ui/Listener.js
+++ b/src-ui/js/ui/Listener.js
@@ -64,6 +64,8 @@ ui.listener = {
 		ui.event.addVisibilityCallback(function() {
 			ui.timer.start();
 		});
+
+		ui.network.start();
 	},
 
 	//---------------------------------------------------------------------------

--- a/src-ui/js/ui/Listener.js
+++ b/src-ui/js/ui/Listener.js
@@ -20,6 +20,8 @@ ui.listener = {
 
 		puzzle.on("adjust", this.onAdjust);
 		puzzle.on("resize", this.onResize);
+
+		puzzle.on("cellop", this.onCellOp);
 	},
 
 	//---------------------------------------------------------------------------
@@ -167,5 +169,9 @@ ui.listener = {
 		puzzle.canvas.parentNode.style.paddingTop = valTop + "px";
 
 		ui.keypopup.resizepanel();
+	},
+
+	onCellOp: function(puzzle, op) {
+		ui.network.onCellOp(op);
 	}
 };

--- a/src-ui/js/ui/MenuArea.js
+++ b/src-ui/js/ui/MenuArea.js
@@ -218,6 +218,7 @@ ui.menuarea = {
 		this.setdisplay("operation");
 		this.setdisplay("trialmode");
 		this.setdisplay("toolarea");
+		this.setdisplay("networkplay");
 
 		/* キャプションの設定 */
 		for (var i = 0; i < this.captions.length; i++) {
@@ -244,6 +245,10 @@ ui.menuarea = {
 				str = ui.selectStr("ツールエリアを隠す", "Hide tool area");
 			}
 			getEL("menu_toolarea").textContent = str;
+		} else if (idname === "networkplay") {
+			getEL("menu_network").className = ui.puzzle.opemgr.enableNetwork
+				? ""
+				: "disabled";
 		} else if (this.menuitem === null || !this.menuitem[idname]) {
 			/* DO NOTHING */
 		} else if (ui.menuconfig.valid(idname)) {

--- a/src-ui/js/ui/Network.js
+++ b/src-ui/js/ui/Network.js
@@ -8,6 +8,7 @@
 		configure: function(mode, key) {
 			this.mode = mode;
 			this.key = key;
+			ui.setdisplay("network");
 		},
 
 		start: function() {

--- a/src-ui/js/ui/Network.js
+++ b/src-ui/js/ui/Network.js
@@ -3,6 +3,7 @@
 		ws: null,
 		mode: "",
 		key: "",
+		maxSeen: -1,
 
 		configure: function(mode, key) {
 			this.mode = mode;
@@ -35,7 +36,12 @@
 		},
 
 		onmessage: function(event) {
-			ui.network.applyOp(event.data);
+			var msg = JSON.parse(event.data);
+			var id = msg.id;
+			if (id > ui.network.maxSeen) {
+				ui.network.maxSeen = id;
+				ui.network.applyOp(msg.operation);
+			}
 		},
 
 		applyOp: function(encOp) {

--- a/src-ui/js/ui/PopupMenu.js
+++ b/src-ui/js/ui/PopupMenu.js
@@ -923,3 +923,26 @@ ui.popupmgr.addpopup("dispsize", {
 ui.popupmgr.addpopup("about", {
 	formname: "about"
 });
+
+ui.popupmgr.addpopup("network", {
+	formname: "network", // just to fit in with how popup template works
+	urlanchor: null,
+	key: "",
+
+	init: function() {
+		ui.popupmgr.popups.template.init.call(this);
+		this.urlanchor = getEL("urlanchor_network");
+		this.key = Math.random()
+			.toString(36)
+			.substr(2, 8);
+	},
+
+	coop: function(px, py) {
+		var parser = pzpr.parser;
+		var url = ui.puzzle.getURL(parser.URL_PZPRV3);
+		url = url.replace("?", "?net=coop&key=" + this.key + "&");
+		this.urlanchor.href = this.urlanchor.textContent = url;
+		ui.network.configure("coop", this.key);
+		ui.network.start();
+	}
+});

--- a/src-ui/js/ui/ToolArea.js
+++ b/src-ui/js/ui/ToolArea.js
@@ -152,6 +152,7 @@ ui.toolarea = {
 				? ""
 				: "none";
 		this.setdisplay("trialmode");
+		this.setdisplay("network");
 
 		/* 共通：キャプションの設定 */
 		/* --------------------- */
@@ -213,6 +214,15 @@ ui.toolarea = {
 			getEL("btnclear").disabled = trialstage > 0;
 			getEL("btntrial").disabled = trialstage > 0;
 			getEL("btntrialarea").style.display = trialstage > 0 ? "block" : "none";
+		} else if (idname === "network") {
+			/* hide redo/undo and trial mode controls
+			   hide instead of disable not least to be orthogonal to "operation"/"trialmode"
+			   blocks above */
+			var net = ui.network.mode !== "";
+			getEL("btnundo").style.display = net ? "none" : "inline";
+			getEL("btnredo").style.display = net ? "none" : "inline";
+			getEL("btntrial").style.display = net ? "none" : "inline";
+			getEL("btntrialarea").style.display = net ? "none" : "block";
 		} else if (this.items === null || !this.items[idname]) {
 			/* DO NOTHING */
 		} else if (ui.menuconfig.valid(idname)) {

--- a/src-ui/js/ui/UI.js
+++ b/src-ui/js/ui/UI.js
@@ -33,6 +33,7 @@ window.ui = {
 	popupmgr: null,
 	keypopup: null,
 	timer: null,
+	network: null,
 
 	enableGetText: false, // FileReader APIの旧仕様でファイルが読めるか
 	enableReadText: false, // HTML5 FileReader APIでファイルが読めるか

--- a/src-ui/p.html
+++ b/src-ui/p.html
@@ -421,7 +421,7 @@
   <div class="popup">
     <div class="titlebar">__URL出力__Export URL__</div>
     <form name="urloutput">
-      <a id="urlanchor" target="_blank"></a>
+      <a id="urlanchor" class="urlanchor" target="_blank"></a>
       <br>
       <button type="button" class="btn" data-button-exec="urloutput" name="kanpen" >__カンペンのURLを出力する__Change to Kanpen URL__</button><br>
       <button type="button" class="btn" data-button-exec="urloutput" name="heyaapp">__へやわけアプレットのURLを出力する__Change to Heyawake-Applet URL__</button><br>

--- a/src-ui/p.html
+++ b/src-ui/p.html
@@ -34,6 +34,8 @@
      <li class="link" data-linktype="duplicate" id="menu_duplicate"><a target="_blank">__盤面の複製__Duplicate the board__</a></li>
      <hr>
      <li data-popup="imagesave" id="menu_imagesave"><span>__画像を保存__Save as image file__</span></li>
+     <hr>
+     <li data-popup="network" id="menu_network"><span>__Network play (please translate)__Network play__</span></li>
    </menu></li>
    <li id="menu_edit"><span>__編集__Edit__</span><menu label="__編集__Edit__">
      <li data-popup="adjust" id="menu_adjust"><span>__盤面の調整__Adjust the board__</span></li>
@@ -587,6 +589,17 @@
     <div class="panelbase" id="panelbase3"></div>
   </div>
 
+  <div class="popup">
+    <div class="titlebar">__Network play (please translate)__Network play__</div>
+    <form name="network">
+    <button type="button" class="btn" data-button-exec="coop">Start</button>
+    <br>
+    Share this link to play with someone: <br>
+    <a id="urlanchor_network" class="urlanchor" target="_blank"></a>
+    <br>
+    <button type="button" class="btn" data-button-exec="close">__閉じる__Close__</button>
+    </form>
+  </div>
 </div>
 
 <!-- 隠し要素 -->

--- a/src/puzzle/Operation.js
+++ b/src/puzzle/Operation.js
@@ -445,6 +445,8 @@ pzpr.classmgr.makeCommon({
 			this.redoExec = false; // Redo中
 			this.reqReset = false; // Undo/Redo時に盤面回転等が入っていた時、resize,rebuildInfo関数のcallを要求する
 
+			this.enableNetwork = true;
+
 			var classes = this.klass;
 			this.operationlist = [
 				classes.ObjectOperation,

--- a/src/puzzle/Operation.js
+++ b/src/puzzle/Operation.js
@@ -37,6 +37,7 @@ pzpr.classmgr.makeCommon({
 		toJSON: function() {
 			return this.toString();
 		},
+		broadcast: function() {},
 
 		//---------------------------------------------------------------------------
 		// ope.undo()  操作opeを一手前に戻す
@@ -130,6 +131,9 @@ pzpr.classmgr.makeCommon({
 				prefix += this.pos;
 			}
 			return [prefix, this.bx, this.by, this.old, this.num].join(",");
+		},
+		broadcast: function() {
+			this.puzzle.emit("cellop", this.toJSON());
 		},
 
 		//---------------------------------------------------------------------------
@@ -597,6 +601,8 @@ pzpr.classmgr.makeCommon({
 			if (!this.puzzle.ready || (!this.forceRecord && this.disrec > 0)) {
 				return;
 			}
+
+			newope.broadcast();
 
 			/* Undoした場所で以降の操作がある時に操作追加された場合、以降の操作は消去する */
 			if (this.enableRedo) {

--- a/src/puzzle/Operation.js
+++ b/src/puzzle/Operation.js
@@ -7,6 +7,8 @@ pzpr.classmgr.makeCommon({
 	// ★Operation(派生)クラス 単体の操作情報を保持する
 	//---------------------------------------------------------------------------
 	Operation: {
+		external: false,
+
 		initialize: function() {
 			this.manager = this.puzzle.opemgr;
 
@@ -133,6 +135,9 @@ pzpr.classmgr.makeCommon({
 			return [prefix, this.bx, this.by, this.old, this.num].join(",");
 		},
 		broadcast: function() {
+			if (this.external) {
+				return;
+			}
 			this.puzzle.emit("cellop", this.toJSON());
 		},
 

--- a/src/variety/kouchoku.js
+++ b/src/variety/kouchoku.js
@@ -857,6 +857,7 @@
 	OperationManager: {
 		addExtraOperation: function() {
 			this.operationlist.push(this.klass.SegmentOperation);
+			this.enableNetwork = false;
 		}
 	},
 


### PR DESCRIPTION
This adds cooperative network play, the server component handled by https://github.com/robx/puzzld.

Current state:

- network play can be activated through a popup (generating a shareable link) or by loading from such a shareable link
- during network play
  - any piece changes (that didn't come from the server) are sent to the server
  - any piece changes that come from the server are applied to the board

Current limitations:

- interaction with trial mode and history is unclear and probably broken
- ~~if you join late, you start with an empty board~~
- no support for non-piece operations
- the puzzle definition itself is not communicated
- pretty hacky, but in an isolated way

It's already pretty fun, so I'd like to merge this soon. I think it should be ok with the following changes:

- [x] disable trial mode and undo/redo during network play
- [x] disable network play for puzzle types which can't work (that use custom operations)
- [x] fetch initial board state from server when joining (requires server work)
