### PR TITLE
General: Do not overwrite existing cell contents.

### DIFF
--- a/src/variety-common/MouseInput.js
+++ b/src/variety-common/MouseInput.js
@@ -47,6 +47,13 @@ pzpr.classmgr.makeCommon({
 				}
 			}
 
+			var cell_already_assigned = cell.qans !== 0 || cell.qsub !== 0;
+			var clearing_cells = this.inputData === 0;
+			var in_starting_cell = cell === this.firstCell;
+			if (!in_starting_cell && !clearing_cells && cell_already_assigned) {
+				return;
+			}
+
 			cell.setQans(this.inputData === 1 ? 1 : 0);
 			cell.setQsub(this.inputData === 2 ? 1 : 0);
 


### PR DESCRIPTION
This is an experiment to see how different it would be if existing cell contents were not overwritten when dragging the pointer around. 

This is mostly useful for types like Heyawake or Yajisan-Kazusan where it is often desirable to mark several non-adjacent empty cells as unshaded. With mouse input, this behaviour was already present when using the right mouse button, but a similar feature did not work for touch inputs.