### PR TITLE
Tents: Various trial fixes for qinfo

### DIFF
--- a/src/puzzle/Operation.js
+++ b/src/puzzle/Operation.js
@@ -875,6 +875,7 @@ pzpr.classmgr.makeCommon({
 				return;
 			}
 			this.disableRecord();
+			this.board.errclear();
 			if (rejectall || this.trialpos.length === 1) {
 				var pos = this.trialpos[0];
 				this.board.trialclear();

--- a/src/variety/tents.js
+++ b/src/variety/tents.js
@@ -442,6 +442,9 @@
 					case 2:
 						g.vid = "c_tentouter_" + cell.id;
 						var color = this.getAnsNumberColor(cell);
+						if (cell.getNum() === -1 && this.board.trialstage > 0) {
+							color = this.trialcolor;
+						}
 						g.fillStyle = color;
 						g.beginPath();
 						g.setOffsetLinePath(


### PR DESCRIPTION
Partial #184

* All errors and info is cleared when rejecting a trial. This should happen for all puzzle types.
* When inside a trial mode, qinfo tents are always drawn with a trial color