### PR TITLE
Added more double quotes

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "node": ">= 5.6.0"
   },
   "scripts": {
-    "build": "eslint --cache --quiet src src-ui && ./git-hash.sh && grunt default",
+    "build": "eslint --cache --quiet src src-ui && \"./git-hash.sh\" && grunt default",
     "release": "npm run clean && eslint --cache --quiet src && grunt release",
     "clean": "del dist/* pzpr-*.{zip,tar.gz,tar.bz2,tgz}",
     "format": "prettier --write \"{src,src-ui,test}/**/*.{js,css}\"",


### PR DESCRIPTION
Haven't tested on non-Windows platforms but seems to fix the other windows problem:
```
'.' is not recognized as an internal or external command,
operable program or batch file.
```