### PR TITLE
Update Japanese translations based on twitter-shared document

### DIFF
--- a/src-ui/p.html
+++ b/src-ui/p.html
@@ -35,7 +35,7 @@
      <hr>
      <li data-popup="imagesave" id="menu_imagesave"><span>__画像を保存__Save as image file__</span></li>
      <hr>
-     <li data-popup="network" id="menu_network"><span>__Network play (please translate)__Network play__</span></li>
+     <li data-popup="network" id="menu_network"><span>__ネットワークプレイ__Network play__</span></li>
    </menu></li>
    <li id="menu_edit"><span>__編集__Edit__</span><menu label="__編集__Edit__">
      <li data-popup="adjust" id="menu_adjust"><span>__盤面の調整__Adjust the board__</span></li>
@@ -592,7 +592,7 @@
   </div>
 
   <div class="popup">
-    <div class="titlebar">__Network play (please translate)__Network play__</div>
+    <div class="titlebar">__ネットワークプレイ__Network play__</div>
     <form name="network">
     <button type="button" class="btn" data-button-exec="coop">Start</button>
     <br>

--- a/src-ui/p.html
+++ b/src-ui/p.html
@@ -148,8 +148,8 @@
       <div class="child" data-value="mark-circle">__丸記号__Circles__</div>
       <div class="child" data-value="mark-triangle">__三角形__Triangles__</div>
       <div class="child" data-value="mark-rect">__四角形__Rectangles__</div>
-      <div class="child" data-value="mark-tree">__(please translate) Trees__Trees__</div>
-      <div class="child" data-value="mark-tent">__(please translate) Tents__Tents__</div>
+      <div class="child" data-value="mark-tree">__木__Trees__</div>
+      <div class="child" data-value="mark-tent">__テント__Tents__</div>
       <div class="child" data-value="undef">__？記号__Question marks__</div>
       <div class="child" data-value="line">__線__Lines__</div>
       <div class="child" data-value="peke">__バツ印__Cross marks__</div>

--- a/src-ui/rules.html
+++ b/src-ui/rules.html
@@ -94,7 +94,7 @@ pzpr.on("load", function(){
     render(player, url, 'player', function(puzzle){});
 
     heading = document.createElement('h1');
-    heading.textContent = "Example errors / エラー例";
+    heading.textContent = "Example errors / 誤答例";
     body.appendChild(heading);
     failcheck.forEach(function(data){
       if(data.length>2&&data[2].skiprules){ return;}

--- a/src-ui/rules.html
+++ b/src-ui/rules.html
@@ -86,7 +86,7 @@ pzpr.on("load", function(){
     var body = document.getElementsByTagName('body')[0];
 
     var heading = document.createElement('h1');
-    heading.textContent = "Example player";
+    heading.textContent = "Example player / 例題";
     body.appendChild(heading);
     var player = document.createElement('div');
     player.className = 'player';
@@ -94,7 +94,7 @@ pzpr.on("load", function(){
     render(player, url, 'player', function(puzzle){});
 
     heading = document.createElement('h1');
-    heading.textContent = "Example errors";
+    heading.textContent = "Example errors / エラー例";
     body.appendChild(heading);
     failcheck.forEach(function(data){
       if(data.length>2&&data[2].skiprules){ return;}

--- a/src/pzpr/variety.js
+++ b/src/pzpr/variety.js
@@ -126,7 +126,7 @@
 			detour: [0, 0, "Detour", "Detour", "country"],
 			doppelblock: [0, 0, "Doppelblock", "Doppelblock", "doppelblock"],
 			dosufuwa: [0, 0, "ドッスンフワリ", "Dosun-Fuwari"],
-			doubleback: [0, 0, "引き返す", "Double Back", "country"],
+			doubleback: [0, 0, "Double Back", "Double Back", "country"],
 			easyasabc: [0, 0, "ABCプレース", "Easy as ABC"],
 			factors: [0, 0, "因子の部屋", "Rooms of Factors"],
 			fillmat: [1, 0, "フィルマット", "Fillmat", "fillmat"],
@@ -319,7 +319,7 @@
 			"yajilin-regions": [
 				0,
 				0,
-				"ヤジリン",
+				"ヘヤジリン",
 				"Regional Yajilin",
 				"yajilin",
 				{ alias: "yajirin-regions" }

--- a/src/variety-common/Answer.js
+++ b/src/variety-common/Answer.js
@@ -1082,7 +1082,7 @@ pzpr.classmgr.makeCommon({
 	FailCode: {
 		/* ** 黒マス ** */
 		cs2x2: [
-			"2x2の黒マスのかたまりがあります。",
+			"2x2の黒マスのカタマリがあります。",
 			"There is a 2x2 block of shaded cells."
 		],
 		csNotSquare: [
@@ -1191,7 +1191,7 @@ pzpr.classmgr.makeCommon({
 		/* ** 線でつなぐ系 ** */
 		lcDeadEnd: ["線が途中で途切れています。", "There is a dead-end line."],
 		lcDivided: [
-			"線が全体で一つながりになっていません。",
+			"線が全体でひとつながりになっていません。",
 			"All lines and numbers are not connected to each other."
 		],
 		lcTripleNum: [

--- a/src/variety/aquarium.js
+++ b/src/variety/aquarium.js
@@ -421,7 +421,7 @@
 			"A water cell is next to or above an empty cell."
 		],
 		csNoLevel: [
-			"一繋がりの水のマスの水位が等しくなっていません。",
+			"一つながりの水のマスの水位が等しくなっていません。",
 			"A body of water has different surface levels."
 		],
 		bkNoLevel: [
@@ -429,7 +429,7 @@
 			"A region has different water surface levels."
 		],
 		exShadeNe: [
-			"行・列内にある水のマスの数と外の数字が異なります。",
+			"行または列内にある水のマスの数と外の数字が異なります。",
 			"The number of shaded cells in the row or column is not correct."
 		]
 	}

--- a/src/variety/aquarium.js
+++ b/src/variety/aquarium.js
@@ -421,7 +421,7 @@
 			"A water cell is next to or above an empty cell."
 		],
 		csNoLevel: [
-			"一つながりの水のマスの水位が等しくなっていません。",
+			"ひとつながりの水のマスの水位が等しくなっていません。",
 			"A body of water has different surface levels."
 		],
 		bkNoLevel: [

--- a/src/variety/balance.js
+++ b/src/variety/balance.js
@@ -414,25 +414,16 @@
 		}
 	},
 	FailCode: {
-		segShort: [
-			"(please translate) A segment is too short.",
-			"A segment is too short."
-		],
-		segLong: [
-			"(please translate) A segment is too long.",
-			"A segment is too long."
-		],
+		segShort: ["線の長さの和が数字より小さいです。", "A segment is too short."],
+		segLong: ["線の長さの和が数字より大きいです。", "A segment is too long."],
 		segWhiteUneq: [
-			"(please translate) Segments through a white circle are different.",
+			"白丸から線の端までの長さが異なっています。",
 			"Segments through a white circle are different."
 		],
 		segBlackEq: [
-			"(please translate) Segments through a black circle are equal.",
+			"黒丸から線の端までの長さが同じになっています。",
 			"Segments through a black circle are equal."
 		],
-		circNoLine: [
-			"(please translate) A circle has no line.",
-			"A circle has no line."
-		]
+		circNoLine: ["線が通っていない丸があります。", "A circle has no line."]
 	}
 });

--- a/src/variety/cbblock.js
+++ b/src/variety/cbblock.js
@@ -645,19 +645,19 @@
 			"A block contains a single color."
 		],
 		bkSubGt2: [
-			"同じ色のマスのかたまりが3個以上入っているブロックがあります。",
+			"同じ色のマスのカタマリが3個以上入っているブロックがあります。",
 			"A block has three or more shapes."
 		],
 		bkSizeLt: [
-			"同じ色のマスのかたまりの大きさより数字が大きいです。",
+			"同じ色のマスのカタマリの大きさより数字が大きいです。",
 			"A number is bigger than the size of the shape."
 		],
 		bkSizeGt: [
-			"同じ色のマスのかたまりの大きさより数字が小さいです。",
+			"同じ色のマスのカタマリの大きさより数字が小さいです。",
 			"A number is smaller than the size of the shape."
 		],
 		bkDifferentShape: [
-			"同じ形でないマスの塊を含むブロックがあります。",
+			"同じ形でないマスのカタマリを含むブロックがあります。",
 			"The two shapes inside a block are different."
 		]
 	}

--- a/src/variety/cbblock.js
+++ b/src/variety/cbblock.js
@@ -645,15 +645,15 @@
 			"A block contains a single color."
 		],
 		bkSubGt2: [
-			"同じ色のマスの塊が3個以上入っているブロックがあります。",
+			"同じ色のマスのかたまりが3個以上入っているブロックがあります。",
 			"A block has three or more shapes."
 		],
 		bkSizeLt: [
-			"数字よりも少ないマス数しかない同じ色のマスの塊があります。",
+			"同じ色のマスのかたまりの大きさより数字が大きいです。",
 			"A number is bigger than the size of the shape."
 		],
 		bkSizeGt: [
-			"数字よりも大きいマス数になっている同じ色のマスの塊があります。",
+			"同じ色のマスのかたまりの大きさより数字が小さいです。",
 			"A number is smaller than the size of the shape."
 		],
 		bkDifferentShape: [

--- a/src/variety/country.js
+++ b/src/variety/country.js
@@ -1133,7 +1133,7 @@
 	},
 	"FailCode@detour": {
 		blWrongTurns: [
-			"A room has the wrong number of turns.",
+			"線の曲がった回数が数字と違っています。",
 			"A room has the wrong number of turns."
 		]
 	}

--- a/src/variety/haisu.js
+++ b/src/variety/haisu.js
@@ -438,7 +438,7 @@
 			"The line goes through S/G"
 		],
 		haisuError: [
-			"数字を正しい回数目で通過していません。",
+			"(please translate) A number is not passed on the right visit",
 			"A number is not passed on the right visit"
 		]
 	}

--- a/src/variety/haisu.js
+++ b/src/variety/haisu.js
@@ -438,7 +438,7 @@
 			"The line goes through S/G"
 		],
 		haisuError: [
-			"(please translate) A number is not passed on the right visit",
+			"数字を正しい回数目で通過していません。",
 			"A number is not passed on the right visit"
 		]
 	}

--- a/src/variety/kazunori.js
+++ b/src/variety/kazunori.js
@@ -484,7 +484,7 @@
 
 	FailCode: {
 		nmSame2x2: [
-			"同じ数字が2x2のかたまりになっています。",
+			"同じ数字が2x2のカタマリになっています。",
 			"There is a 2x2 block of the same number."
 		],
 		nmSumNe: [

--- a/src/variety/kouchoku.js
+++ b/src/variety/kouchoku.js
@@ -1556,10 +1556,13 @@
 
 	FailCode: {
 		lnIsolate: [
-			"線が丸のないところから出ています。",
+			"線がマークのないところから出ています。",
 			"A segment starts outside a clue."
 		],
-		lnPassOver: ["線が丸を通過しています。", "A segment passes over a clue."],
+		lnPassOver: [
+			"線がマークを通過しています。",
+			"A segment passes over a clue."
+		],
 		lnOverlap: ["線が同一直線上で重なっています。", "Some segments overlap."],
 		lnRightAngle: [
 			"線が直角に交差していません。",

--- a/src/variety/kurodoko.js
+++ b/src/variety/kurodoko.js
@@ -329,7 +329,7 @@
 
 	FailCode: {
 		cu2x2: [
-			"2x2の白マスのかたまりがあります。",
+			"2x2の白マスのカタマリがあります。",
 			"There is a 2x2 block of unshaded cells."
 		],
 		circleNotPromontory: [

--- a/src/variety/nanro.js
+++ b/src/variety/nanro.js
@@ -302,7 +302,7 @@
 			"A block has no number."
 		],
 		nm2x2: [
-			"数字が2x2のかたまりになっています。",
+			"数字が2x2のカタマリになっています。",
 			"There is a 2x2 block of numbers."
 		],
 		cbSameNum: [

--- a/src/variety/nurimaze.js
+++ b/src/variety/nurimaze.js
@@ -686,7 +686,7 @@
 
 	FailCode: {
 		cu2x2: [
-			"2x2の白マスのかたまりがあります。",
+			"2x2の白マスのカタマリがあります。",
 			"There is a 2x2 block of unshaded cells."
 		],
 		cuLoop: [

--- a/src/variety/paintarea.js
+++ b/src/variety/paintarea.js
@@ -142,7 +142,7 @@
 
 	FailCode: {
 		cu2x2: [
-			"2x2の白マスのかたまりがあります。",
+			"2x2の白マスのカタマリがあります。",
 			"There is a 2x2 block of unshaded cells."
 		],
 		nmShadeNe: [

--- a/src/variety/snake.js
+++ b/src/variety/snake.js
@@ -396,7 +396,7 @@
 		],
 		circleUnshade: ["塗られていない丸があります。", "A circle is not shaded."],
 		exShadeNe: [
-			"行・列内にある水のマスの数と外の数字が異なります。",
+			"行または列内にあるスネークのマスの数と外の数字が異なります。",
 			"The number of shaded cells in the row or column is not correct."
 		]
 	}

--- a/src/variety/snake.js
+++ b/src/variety/snake.js
@@ -377,33 +377,24 @@
 
 	FailCode: {
 		cs2x2: [
-			"(please translate) The snake loops back on itself.",
+			"スネークが自分自身とタテヨコナナメに接しています。",
 			"The snake loops back on itself."
 		],
-		shBranch: [
-			"(please translate) The snake branches off.",
-			"The snake branches off."
-		],
-		shLoop: [
-			"(please translate) The snake has no head or tail.",
-			"The snake has no head or tail."
-		],
+		shBranch: ["スネークが分岐しています。", "The snake branches off."],
+		shLoop: ["頭または尾がありません。", "The snake has no head or tail."],
 		shEndpoint: [
-			"(please translate) A black circle is not on an endpoint.",
+			"頭または尾になっていない黒丸があります。",
 			"A black circle is not on an endpoint."
 		],
 		shMidpoint: [
-			"(please translate) A white circle is not a middle.",
+			"胴体になっていない白丸があります。",
 			"A white circle is not a middle."
 		],
 		shDiag: [
-			"(please translate) The snake touches itself diagonally.",
+			"スネークが自分自身とタテヨコナナメに接しています。",
 			"The snake touches itself diagonally."
 		],
-		circleUnshade: [
-			"(please translate) A circle is not shaded.",
-			"A circle is not shaded."
-		],
+		circleUnshade: ["塗られていない丸があります。", "A circle is not shaded."],
 		exShadeNe: [
 			"行・列内にある水のマスの数と外の数字が異なります。",
 			"The number of shaded cells in the row or column is not correct."

--- a/src/variety/tents.js
+++ b/src/variety/tents.js
@@ -720,24 +720,24 @@
 
 	FailCode: {
 		nmTentNone: [
-			"(please translate) A tree has no tent.",
+			"テントが隣り合っていない木があります。",
 			"A tree has no tent."
 		],
 		nmTreeNone: [
-			"(please translate) A tent is not next to a tree.",
+			"木に接していないテントがあります。",
 			"A tent is not next to a tree."
 		],
 		nmTentLt: [
-			"(please translate) There aren't enough tents around a tree.",
+			"木の数よりもテントの数が少ない部分があります。",
 			"There aren't enough tents around a tree."
 		],
 		nmTentGt: [
-			"(please translate) There are too many tents around a tree.",
+			"木の数よりもテントの数が多い部分があります。",
 			"There are too many tents around a tree."
 		],
-		tentAround: ["(please translate) Some tents touch.", "Some tents touch."],
+		tentAround: ["テント同士が接しています。", "Some tents touch."],
 		exTentNe: [
-			"(please translate) The number of tents in the row or column is not correct.",
+			"行または列にあるテントの数が正しくありません。",
 			"The number of tents in the row or column is not correct."
 		]
 	}

--- a/src/variety/yinyang.js
+++ b/src/variety/yinyang.js
@@ -245,11 +245,11 @@
 	FailCode: {
 		ceNoNum: ["まるの入っていないマスがあります。", "There is an empty cell."],
 		ms2x2: [
-			"2x2のくろまるのかたまりがあります。",
+			"2x2のくろまるのカタマリがあります。",
 			"There is a 2x2 block of shaded circles."
 		],
 		mu2x2: [
-			"2x2のしろまるのかたまりがあります。",
+			"2x2のしろまるのカタマリがあります。",
 			"There is a 2x2 block of unshaded circles."
 		],
 		msDivide: [


### PR DESCRIPTION
Compare #15. Some of these change existing Japanese translations; I can't judge whether those are actually improvements. I didn't understand the input mode part for Tents and Trees -- does this mean that I should just leave "Tents" and "Trees" input mode labels in English?

@domishana Do you have an opinion on the changes here?