### PR TITLE
Sukoro rework (skeleton, dragging)

### DIFF
--- a/src-ui/p.html
+++ b/src-ui/p.html
@@ -218,6 +218,7 @@
         <span data-autocmp-type="akari">__光の照らす領域に背景色をつける__Paint background of each illuminated block__</span>
         <span data-autocmp-type="kouchoku">__線が2本以上になったら点をグレーにする__Grey each letter which links over two segments__</span>
         <span data-autocmp-type="border">__異なる数字の間にグレーの境界線を引く__Grey border between different areas__</span>
+        <span data-autocmp-type="skeleton">__(please translate) Skeleton for connected numbers__Skeleton for connected numbers__</span>
       </label>
     </div>
     <div class="config" data-config="autoerr">

--- a/src/puzzle/Config.js
+++ b/src/puzzle/Config.js
@@ -120,17 +120,13 @@
 		// config.getCurrentName() 以前のconfig名から現在使用している名称を取得する
 		// config.getNormalizedName() Config名が@付きだった場合varietyのpidを返す
 		//---------------------------------------------------------------------------
+		// this seems to be about migrating settings from old to new name
 		getCurrentName: function(name) {
 			switch (name) {
 				case "color_qanscolor":
 					name = "color_shadecolor";
 					break;
 				case "autocmp_area":
-					if (this.getexec("autocmp")) {
-						name = "autocmp";
-					}
-					break;
-				case "autocmp_border":
 					if (this.getexec("autocmp")) {
 						name = "autocmp";
 					}

--- a/src/variety/shakashaka.js
+++ b/src/variety/shakashaka.js
@@ -366,42 +366,11 @@
 				return cell.isTri();
 			};
 			return this.qnum === this.countDir4Cell(is_tri);
-		},
-
-		posthook: {
-			qnum: function() {
-				this.redrawAdjacent();
-			},
-			qans: function() {
-				this.redrawAdjacent();
-			},
-			qsub: function() {
-				this.redrawAdjacent();
-			}
-		},
-
-		redrawAdjacent: function() {
-			var ad = this.adjacent;
-			var cells = new this.klass.CellList([
-				ad.top,
-				ad.right,
-				ad.bottom,
-				ad.left
-			]);
-			this.board.redrawAffected(cells);
 		}
 	},
 	Board: {
 		addExtraInfo: function() {
 			this.wrectmgr = this.addInfoList(this.klass.AreaWrectGraph);
-		},
-		redrawAffected: function(cells) {
-			for (var i = 0; i < cells.length; i++) {
-				var c = cells[i];
-				if (!c.isnull && c.qnum !== -1 && c.qnum !== -2) {
-					c.draw();
-				}
-			}
 		}
 	},
 	BoardExec: {
@@ -475,6 +444,19 @@
 		fgcellcolor_func: "qnum",
 		fontShadecolor: "white",
 		qcmpcolor: "rgb(127,127,127)",
+
+		setRange: function(x1, y1, x2, y2) {
+			var puzzle = this.puzzle,
+				bd = puzzle.board;
+			if (puzzle.execConfig("autocmp")) {
+				x1 = bd.minbx - 2;
+				y1 = bd.minby - 2;
+				x2 = bd.maxbx + 2;
+				y2 = bd.maxby + 2;
+			}
+
+			this.common.setRange.call(this, x1, y1, x2, y2);
+		},
 
 		paint: function() {
 			this.drawBGCells();

--- a/src/variety/sukoro.js
+++ b/src/variety/sukoro.js
@@ -11,6 +11,20 @@
 	//---------------------------------------------------------
 	// マウス入力系
 	MouseEvent: {
+		dragnumber_sukoro: function() {
+			var cell = this.getcell();
+			if (cell.isnull || cell === this.mouseCell) {
+				return;
+			}
+			if (this.mouseCell.isnull) {
+				this.inputData = cell.isNumberObj() ? -2 : -3;
+				this.mouseCell = cell;
+			} else if (cell.qnum === -1) {
+				cell.setNum(this.inputData);
+				this.mouseCell = cell;
+				cell.draw();
+			}
+		},
 		// like normal, except we sort qsub=1 to the front
 		getNewNumber: function(cell, num) {
 			var puzzle = this.puzzle;
@@ -75,7 +89,16 @@
 			play: ["number", "numexist", "numblank", "clear"]
 		},
 		mouseinput_auto: function() {
-			if (this.mousestart) {
+			if (this.puzzle.playmode) {
+				if (this.mousestart || this.mousemove) {
+					if (this.btn === "left") {
+						this.dragnumber_sukoro();
+					}
+				} else if (this.mouseend && this.notInputted()) {
+					this.mouseCell = this.board.emptycell;
+					this.inputqnum();
+				}
+			} else if (this.puzzle.editmode) {
 				this.inputqnum();
 			}
 		}

--- a/src/variety/sukoro.js
+++ b/src/variety/sukoro.js
@@ -104,15 +104,16 @@
 		minnum: 0
 	},
 
+	Board: {
+		hasborder: 1
+	},
 	"Board@view": {
 		cols: 8,
 		rows: 8
 	},
 	"Board@sukororoom": {
 		cols: 8,
-		rows: 8,
-
-		hasborder: 1
+		rows: 8
 	},
 
 	AreaNumberGraph: {
@@ -130,6 +131,7 @@
 			if (this.pid === "view") {
 				this.drawTargetSubNumber();
 			}
+			this.drawSkeleton();
 			this.drawGrid();
 
 			if (this.pid === "sukororoom") {
@@ -146,6 +148,50 @@
 			this.drawChassis();
 
 			this.drawCursor();
+		},
+
+		drawSkeleton: function() {
+			this.drawSkeletonDots();
+			this.drawSkeletonEdges();
+		},
+		drawSkeletonDots: function() {
+			var g = this.vinc("cell_skel_dot", "auto", true);
+
+			var dsize = this.cw * 0.2;
+			var clist = this.range.cells;
+			for (var i = 0; i < clist.length; i++) {
+				var cell = clist[i];
+
+				g.vid = "c_dot_" + cell.id;
+				if (cell.isNumberObj()) {
+					g.fillStyle = this.bcolor;
+					g.fillCircle(cell.bx * this.bw, cell.by * this.bh, dsize);
+				} else {
+					g.vhide();
+				}
+			}
+		},
+		drawSkeletonEdges: function() {
+			var g = this.vinc("cell_skel_edge", "auto", true);
+
+			var dsize = this.cw * 0.2;
+			var blist = this.range.borders;
+			for (var i = 0; i < blist.length; i++) {
+				var b = blist[i];
+
+				g.vid = "b_skel_" + b.id;
+				var isedgevalid =
+					this.board.nblkmgr.isnodevalid(b.sidecell[0]) &&
+					this.board.nblkmgr.isnodevalid(b.sidecell[1]);
+				if (isedgevalid) {
+					var w = b.isvert ? this.bh : dsize;
+					var h = b.isvert ? dsize : this.bw;
+					g.fillStyle = this.bcolor;
+					g.fillRectCenter(b.bx * this.bw, b.by * this.bh, w, h);
+				} else {
+					g.vhide();
+				}
+			}
 		}
 	},
 	"Graphic@view": {

--- a/src/variety/sukoro.js
+++ b/src/variety/sukoro.js
@@ -10,6 +10,65 @@
 })(["sukoro", "view", "sukororoom"], {
 	//---------------------------------------------------------
 	// マウス入力系
+	MouseEvent: {
+		// like normal, except we sort qsub=1 to the front
+		getNewNumber: function(cell, num) {
+			var puzzle = this.puzzle;
+			var max = cell.getmaxnum(),
+				min = cell.getminnum(),
+				val = -1,
+				qs = cell.qsub;
+
+			var subtype = 0;
+			if (puzzle.editmode) {
+				subtype = -1;
+			} else {
+				subtype = 2;
+				qs = cell.qsub;
+			}
+
+			// playmode: subtypeは0以上、 qsにqsub値が入る
+			// editmode: subtypeは-1固定、qsは常に0が入る
+			if (this.btn === "left") {
+				if (num >= max) {
+					val = subtype >= 1 ? -3 : -1;
+				} else if (qs === 1) {
+					val = min;
+				} else if (qs === 2) {
+					val = -1;
+				} else if (num === -1) {
+					val = -2;
+				} else if (num < min) {
+					val = min;
+				} else {
+					val = num + 1;
+				}
+			} else if (this.btn === "right") {
+				if (qs === 1) {
+					val = -1;
+				} else if (qs === 2) {
+					val = max;
+				} else if (num === -1) {
+					if (subtype === 1) {
+						val = -2;
+					} else if (subtype === 2) {
+						val = -3;
+					} else {
+						val = max;
+					}
+				} else if (num > max) {
+					val = max;
+				} else if (num <= min) {
+					val = -2;
+				} else if (num === -2) {
+					val = -1;
+				} else {
+					val = num - 1;
+				}
+			}
+			return val;
+		}
+	},
 	"MouseEvent@sukoro,view": {
 		inputModes: {
 			edit: ["number", "clear"],

--- a/src/variety/sukoro.js
+++ b/src/variety/sukoro.js
@@ -126,6 +126,23 @@
 	//---------------------------------------------------------
 	// 画像表示系
 	Graphic: {
+		autocmp: "skeleton",
+		skelcolor: "rgb(160, 255, 160)", // bcolor
+		qcmpcolor: "darkgray",
+
+		setRange: function(x1, y1, x2, y2) {
+			var puzzle = this.puzzle,
+				bd = puzzle.board;
+			if (puzzle.execConfig("autocmp")) {
+				x1 = bd.minbx - 2;
+				y1 = bd.minby - 2;
+				x2 = bd.maxbx + 2;
+				y2 = bd.maxby + 2;
+			}
+
+			this.common.setRange.call(this, x1, y1, x2, y2);
+		},
+
 		paint: function() {
 			this.drawBGCells();
 			if (this.pid === "view") {
@@ -188,6 +205,13 @@
 					g.strokeStyle = !cell.trial ? this.mbcolor : "rgb(192, 192, 192)";
 				}
 
+				g.vid = "c_MB1_" + cell.id;
+				if (cell.qsub === 1 && !this.puzzle.execConfig("autocmp")) {
+					g.strokeCircle(px, py, rsize);
+				} else {
+					g.vhide();
+				}
+
 				g.vid = "c_MB2_" + cell.id;
 				if (cell.qsub === 2) {
 					g.strokeCross(px, py, rsize);
@@ -202,6 +226,7 @@
 		},
 		drawSkeletonDots: function() {
 			var g = this.vinc("cell_skel_dot", "auto", true);
+			var autocmp = this.puzzle.execConfig("autocmp");
 
 			var dsize = this.cw * 0.2;
 			var clist = this.range.cells;
@@ -209,8 +234,8 @@
 				var cell = clist[i];
 
 				g.vid = "c_dot_" + cell.id;
-				if (cell.isNumberObj()) {
-					g.fillStyle = this.bcolor;
+				if (autocmp && cell.isNumberObj()) {
+					g.fillStyle = this.skelcolor;
 					g.fillCircle(cell.bx * this.bw, cell.by * this.bh, dsize);
 				} else {
 					g.vhide();
@@ -219,10 +244,15 @@
 		},
 		drawSkeletonEdges: function() {
 			var g = this.vinc("cell_skel_edge", "auto", true);
+			var autocmp = this.puzzle.execConfig("autocmp");
 
 			var dsize = this.cw * 0.2;
 			var blist = this.range.borders;
 			for (var i = 0; i < blist.length; i++) {
+				if (!autocmp) {
+					g.vhide();
+					continue;
+				}
 				var b = blist[i];
 
 				g.vid = "b_skel_" + b.id;
@@ -232,7 +262,7 @@
 				if (isedgevalid) {
 					var w = b.isvert ? this.bh : dsize;
 					var h = b.isvert ? dsize : this.bw;
-					g.fillStyle = this.bcolor;
+					g.fillStyle = this.skelcolor;
 					g.fillRectCenter(b.bx * this.bw, b.by * this.bh, w, h);
 				} else {
 					g.vhide();

--- a/src/variety/sukoro.js
+++ b/src/variety/sukoro.js
@@ -237,7 +237,11 @@
 			);
 		},
 		getCmpNumberText: function(cell) {
-			if (cell.anum >= 0 || cell.qnum >= 0) {
+			if (
+				!this.puzzle.execConfig("autocmp") ||
+				cell.anum >= 0 ||
+				cell.qnum >= 0
+			) {
 				return "";
 			}
 			if (cell.qsub === 1) {
@@ -315,17 +319,13 @@
 			var dsize = this.cw * 0.2;
 			var blist = this.range.borders;
 			for (var i = 0; i < blist.length; i++) {
-				if (!autocmp) {
-					g.vhide();
-					continue;
-				}
 				var b = blist[i];
 
 				g.vid = "b_skel_" + b.id;
 				var isedgevalid =
 					this.board.nblkmgr.isnodevalid(b.sidecell[0]) &&
 					this.board.nblkmgr.isnodevalid(b.sidecell[1]);
-				if (isedgevalid) {
+				if (autocmp && isedgevalid) {
 					var w = b.isvert ? this.bh : dsize;
 					var h = b.isvert ? dsize : this.bw;
 					g.fillStyle = this.skelcolor;

--- a/src/variety/sukoro.js
+++ b/src/variety/sukoro.js
@@ -150,6 +150,52 @@
 			this.drawCursor();
 		},
 
+		getAnsNumberText: function(cell) {
+			if (cell.anum >= 0) {
+				return this.getNumberText(cell, cell.anum);
+			}
+			if (cell.qsub === 1) {
+				var c = cell.countDir4Cell(function(cell) {
+					return cell.isNumberObj();
+				});
+				return this.getNumberText(cell, c);
+			}
+			return "";
+		},
+		getAnsNumberColor: function(cell) {
+			if ((cell.error || cell.qinfo) === 1) {
+				return this.errcolor1;
+			}
+			if (cell.qsub === 1) {
+				return this.qcmpcolor;
+			}
+			return !cell.trial ? this.qanscolor : this.trialcolor;
+		},
+
+		drawMBs: function() {
+			var g = this.vinc("cell_mb", "auto", true);
+			g.lineWidth = 1;
+
+			var rsize = this.cw * 0.35;
+			var clist = this.range.cells;
+			for (var i = 0; i < clist.length; i++) {
+				var cell = clist[i],
+					px,
+					py;
+				if (cell.qsub > 0) {
+					px = cell.bx * this.bw;
+					py = cell.by * this.bh;
+					g.strokeStyle = !cell.trial ? this.mbcolor : "rgb(192, 192, 192)";
+				}
+
+				g.vid = "c_MB2_" + cell.id;
+				if (cell.qsub === 2) {
+					g.strokeCross(px, py, rsize);
+				} else {
+					g.vhide();
+				}
+			}
+		},
 		drawSkeleton: function() {
 			this.drawSkeletonDots();
 			this.drawSkeletonEdges();

--- a/src/variety/sukoro.js
+++ b/src/variety/sukoro.js
@@ -161,15 +161,25 @@
 			}
 			this.drawAnsNumbers();
 			this.drawQuesNumbers();
+			this.drawCmpNumbers();
 
 			this.drawChassis();
 
 			this.drawCursor();
 		},
 
-		getAnsNumberText: function(cell) {
-			if (cell.anum >= 0) {
-				return this.getNumberText(cell, cell.anum);
+		drawCmpNumbers: function() {
+			this.vinc("cell_cmp_number", "auto");
+			this.drawNumbers_com(
+				this.getCmpNumberText,
+				this.getCmpNumberColor,
+				"cell_cmp_text_",
+				{ ratio: 0.45 }
+			);
+		},
+		getCmpNumberText: function(cell) {
+			if (cell.anum >= 0 || cell.qnum >= 0) {
+				return "";
 			}
 			if (cell.qsub === 1) {
 				var c = cell.countDir4Cell(function(cell) {
@@ -179,14 +189,11 @@
 			}
 			return "";
 		},
-		getAnsNumberColor: function(cell) {
+		getCmpNumberColor: function(cell) {
 			if ((cell.error || cell.qinfo) === 1) {
 				return this.errcolor1;
 			}
-			if (cell.qsub === 1) {
-				return this.qcmpcolor;
-			}
-			return !cell.trial ? this.qanscolor : this.trialcolor;
+			return this.qcmpcolor;
 		},
 
 		drawMBs: function() {


### PR DESCRIPTION
Couple changes to make sukoro nicer:

- Visual mode where a skeleton is drawn behind numbers. Circles are replaced with just skeleton, and computed number of neighbours.
- Some support for dragging; dragging numbers always creates circles/skeleton.

Not quite done yet. Current state: https://garp.vllmrt.net/scratch/sukoro/p.html?sukoro/9/9/b1c3c1b2b4a1a1e3j3b1b1j2e4a2d1b2a1a3c2b

Todo:

- answer check should be ok with circles / skeleton only, no need to input all numbers
- mouse input is still a bit weird: right-button dragging of Xs; also apply to sukororoom
- get rid of keyboard player input / cursor entirely?
- when solving, it would be nice to be able to "lock in" an automatically computed value; perhaps give it a different color when all neighbour cells are marked?