### PR TITLE
Service worker

### DIFF
--- a/src-ui/js/ui/Boot.js
+++ b/src-ui/js/ui/Boot.js
@@ -5,6 +5,7 @@
 	/* 初期化時のみ使用するルーチン */
 	/********************************/
 
+	var onload_pzv = null;
 	var onload_pzl = null;
 	var onload_option = {};
 
@@ -23,7 +24,7 @@
 		if (!onload_pzl) {
 			/* 1) 盤面複製・index.htmlからのファイル入力/Database入力か */
 			/* 2) URL(?以降)をチェック */
-			onload_pzl = importFileData() || importURL();
+			onload_pzl = importURL();
 
 			/* 指定されたパズルがない場合はさようなら～ */
 			if (!onload_pzl || !onload_pzl.pid) {
@@ -43,11 +44,11 @@
 			title2.innerHTML = "Fail to import puzzle data or URL.";
 		}
 		document.getElementById("menupanel").innerHTML = "";
-		//throw new Error("No Include Puzzle Data Exception");
 	}
 
 	function startPuzzle() {
 		var pzl = onload_pzl;
+		ui.pzv = onload_pzv; // for the puzz.link callback
 
 		/* IE SVGのtextLengthがうまく指定できていないので回避策を追加 */
 		if (
@@ -88,11 +89,8 @@
 	// ★importURL() 初期化時にURLを解析し、パズルの種類・エディタ/player判定を行う
 	//---------------------------------------------------------------------------
 	function importURL() {
-		/* index.htmlからURLが入力されたかチェック */
-		var search = getStorageData("pzprv3_urldata", "urldata");
-
 		/* index.htmlからURLが入力されていない場合は現在のURLの?以降をとってくる */
-		search = search || location.search;
+		var search = location.search;
 		if (!search) {
 			return null;
 		}
@@ -107,43 +105,11 @@
 			search = RegExp.$3;
 		}
 
+		onload_pzv = search;
 		var pzl = pzpr.parser.parseURL(search);
 		var startmode = pzl.mode || (!pzl.body ? "editor" : "player");
 		onload_option.type = onload_option.type || startmode;
 
 		return pzl;
-	}
-
-	//---------------------------------------------------------------------------
-	// ★importFileData() 初期化時にファイルデータの読み込みを行う
-	//---------------------------------------------------------------------------
-	function importFileData() {
-		/* index.htmlや盤面の複製等でファイルorブラウザ保存データが入力されたかチェック */
-		var fstr = getStorageData("pzprv3_filedata", "filedata");
-		if (!fstr) {
-			return null;
-		}
-
-		var pzl = pzpr.parser.parseFile(fstr, "");
-		if (!pzl) {
-			return null;
-		}
-
-		return pzl;
-	}
-
-	//---------------------------------------------------------------------------
-	// ★getStorageData() localStorageやsesseionStorageのデータを読み込む
-	//---------------------------------------------------------------------------
-	function getStorageData(key, key2) {
-		// 移し変える処理
-		var str = localStorage[key];
-		if (typeof str === "string") {
-			delete localStorage[key];
-			sessionStorage[key2] = str;
-		}
-
-		str = sessionStorage[key2];
-		return typeof str === "string" ? str : null;
 	}
 })();

--- a/src-ui/p.html
+++ b/src-ui/p.html
@@ -9,8 +9,14 @@
 <link rel="icon" type="image/png" sizes="16x16" href="./favicon-16x16.png">
 <link rel="manifest" href="./site.webmanifest">
 <link rel="mask-icon" href="./safari-pinned-tab.svg" color="#5bbad5">
-
 <link rel="stylesheet" href="./css/ui.css?<%= git.hash %>" type="text/css">
+<script type="text/javascript">
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', function() {
+    navigator.serviceWorker.register('/sw.js');
+  });
+}
+</script>
 <script type="text/javascript" src="./js/pzpr.js?<%= git.hash %>"></script>
 <script type="text/javascript" src="./js/pzpr-ui.js?<%= git.hash %>"></script>
 <title>puzz.link player</title>

--- a/src-ui/sw.js
+++ b/src-ui/sw.js
@@ -1,0 +1,25 @@
+var CACHE_NAME = "v5";
+var urlsToCache = ["/p"];
+
+self.addEventListener("install", function(event) {
+	event.waitUntil(
+		caches.open(CACHE_NAME).then(function(cache) {
+			return cache.addAll(urlsToCache);
+		})
+	);
+});
+
+self.addEventListener("fetch", function(event) {
+	event.respondWith(
+		caches.open(CACHE_NAME).then(function(cache) {
+			return cache
+				.match(event.request, { ignoreSearch: true })
+				.then(function(response) {
+					if (response) {
+						return response;
+					}
+					return fetch(event.request);
+				});
+		})
+	);
+});


### PR DESCRIPTION
This adds a service worker that caches `https://puzz.link/p` regardless of query parameters. It's live currently.

The intended effect is that once loaded, the HTML for any player links will be loaded from the service worker. Particularly, this *should* speed up load times significantly from across the globe.

Main potential downside that I see right now is this adds complexity, and might make p.html be cached in a more sticky way, causing trouble when p.html needs changes.