### PR TITLE
box: fix editor validity check

### DIFF
--- a/src/variety/box.js
+++ b/src/variety/box.js
@@ -138,7 +138,7 @@
 			if (bx === -1 && by === -1) {
 				return 0;
 			}
-			var size = bx === -1 ? this.board.rows : this.board.cols;
+			var size = bx === -1 ? this.board.cols : this.board.rows;
 			return ((size * (size + 1)) / 2) | 0;
 		},
 		minnum: 0


### PR DESCRIPTION
Previously, the row and column checks were swapped -- for example, when
editing a puzzle with 10 columns and 3 rows, it would allow entering
numbers from 0-55 along the top and 0-6 along the left.