### PR TITLE
hitori: fix encoding of numbers >=16

### DIFF
--- a/src/variety/hitori.js
+++ b/src/variety/hitori.js
@@ -179,9 +179,9 @@
 
 				if (qn === -2) {
 					pstr = "%";
-				} else if (qn >= 0 && qn < 16) {
+				} else if (qn >= 0 && qn < 36) {
 					pstr = qn.toString(36);
-				} else if (qn >= 16 && qn < 256) {
+				} else if (qn >= 36 && qn < 1296) {
 					pstr = "-" + qn.toString(36);
 				} else {
 					count++;


### PR DESCRIPTION
Currently, Hitori clues 16 through 35 are incorrectly encoded as `-g` through `-z` instead of `g` through `z`

e.g. try exporting this to URL:
https://puzz.link/p?type=editor&pzprv3/hitori/7/7/1%2014%201%2015%201%2016%201%20/17%201%2018%201%2019%201%2020%20/1%2021%201%2022%201%2023%201%20/24%201%2025%201%2026%201%2027%20/1%2028%201%2029%201%2030%201%20/31%201%2032%201%2033%201%2034%20/1%2035%201%2036%201%2037%201%20/.%20.%20.%20.%20.%20.%20.%20/.%20.%20.%20.%20.%20.%20.%20/.%20.%20.%20.%20.%20.%20.%20/.%20.%20.%20.%20.%20.%20.%20/.%20.%20.%20.%20.%20.%20.%20/.%20.%20.%20.%20.%20.%20.%20/.%20.%20.%20.%20.%20.%20.%20//