### PR TITLE
Add alternative display mode for Slitherlink

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -15,6 +15,7 @@
 |`dispqnumbg`|`boolean`|`false`|Set background color of question circles silver for `'Yin Yang'`|
 |`undefcell`|`boolean`|`true`|Set background color of undetermined cell for `'School Trip'`|
 |`squarecell`|`boolean`|`true`|Set cell on the board always square|
+|`altline`|`boolean`|`false`|Alternative display mode for `'Slitherlink'`|
 
 ## List of config for input method
 

--- a/src-ui/p.html
+++ b/src-ui/p.html
@@ -292,6 +292,12 @@ if ('serviceWorker' in navigator) {
         <span>__数字・記号をパネルで入力する__Input numbers by panel__</span>
       </label>
     </div>
+    <div class="config" data-config="altline">
+      <label>
+        <input type="checkbox">
+        <span>__ __Alternative display mode__</span>
+      </label>
+    </div>
     <div class="config" data-config="irowake">
       <label>
         <input type="checkbox">

--- a/src/puzzle/Config.js
+++ b/src/puzzle/Config.js
@@ -56,6 +56,7 @@
 			); /* shakashaka: 三角形の入力補助 (for 2つ以上の壁に接したCell) */
 
 			this.add("bgcolor", false); /* slither 背景色入力 */
+			this.add("altline", false); /* slither 背景色入力 */
 			this.add(
 				"singlenum",
 				!pzpr.env.API.touchevent
@@ -328,6 +329,9 @@
 				case "bgcolor":
 					exec = pid === "slither";
 					break;
+				case "altline":
+					exec = pid === "slither";
+					break;
 				case "irowake":
 					exec = puzzle.painter.irowake;
 					break;
@@ -402,6 +406,7 @@
 				case "disptype_yajilin":
 				case "disptype_interbd":
 				case "dispqnumbg":
+				case "altline":
 					puzzle.redraw();
 					break;
 

--- a/src/variety-common/Graphic.js
+++ b/src/variety-common/Graphic.js
@@ -1341,7 +1341,7 @@ pzpr.classmgr.makeCommon({
 			for (var i = 0; i < blist.length; i++) {
 				var border = blist[i];
 				g.vid = "b_peke_" + border.id;
-				if (border.qsub === 2) {
+				if (!this.puzzle.execConfig("altline") && border.qsub === 2) {
 					g.strokeStyle = !border.trial ? this.pekecolor : this.trialcolor;
 					g.strokeCross(border.bx * this.bw, border.by * this.bh, size - 1);
 				} else {

--- a/src/variety/slither.js
+++ b/src/variety/slither.js
@@ -112,6 +112,7 @@
 
 		paint: function() {
 			this.drawBGCells();
+			this.drawBorders();
 			this.drawLines();
 			this.drawBaseMarks();
 			this.drawQuesNumbers();
@@ -122,6 +123,15 @@
 		repaintParts: function(blist) {
 			this.range.crosses = blist.crossinside();
 			this.drawBaseMarks();
+		},
+
+		getBorderColor: function(border) {
+			if (this.puzzle.execConfig("altline") && !border.isLine() && border.qsub !== 2) {
+				return "rgb(220,220,200)";
+			}
+			else {
+				return null;
+			}
 		}
 	},
 


### PR DESCRIPTION
Since I play slitherlink a lot on the implementation in [this](https://www.chiark.greenend.org.uk/~sgtatham/puzzles/) puzzle collection (the game is called loopy), I wanted to have a way display information in a way that is more familiar to me.

This adds an option to slitherlink for an alternative display style which has a base grid of lines in grey and instead of placing peke marks the base line gets removed.

(Japanese translation for the new option (`altline`) is missing as I unfortunately don't speak Japanese.)