### PR TITLE
Graphic.js: darker green for qsubcolor1

### DIFF
--- a/src/puzzle/Graphic.js
+++ b/src/puzzle/Graphic.js
@@ -74,7 +74,7 @@
 			errbcolor1: "rgb(255, 160, 160)",
 			errbcolor2: "rgb(64, 255, 64)",
 
-			qsubcolor1: "rgb(160,255,160)",
+			qsubcolor1: "rgb(60,180,75)",
 			qsubcolor2: "rgb(255,255,127)",
 			qsubcolor3: "rgb(192,192,192)", // 絵が出るパズルの背景入力
 


### PR DESCRIPTION
This makes the green color used for qsubcolor1 (eg, for slither) darker and thus more distinguishable from the yellow used for qsubcolor2 by people with some forms of colorblindness.

The particular color chosen is inspired by https://sashamaps.net/docs/resources/20-colors/ though I am not tweaking the other colors to come from here.

Fixes #255.