### PR TITLE
simpleloop, doubleback, rassi: "empty" cell drawing tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: build test serve format
+
+build:
+	npm run-script build
+
+test:
+	npm test
+
+serve:
+	cd dist && python3 -m http.server -b localhost
+
+serve-all:
+	cd dist && python3 -m http.server
+
+format:
+	npm run-script format

--- a/src/variety/country.js
+++ b/src/variety/country.js
@@ -455,6 +455,11 @@
 		gridcolor_type: "SLIGHT",
 
 		paint: function() {
+			if (this.pid === "country" || this.pid === "ovotovata") {
+				this.drawGrid();
+			} else {
+				this.drawDashedGrid();
+			}
 			this.drawBGCells();
 			if (
 				this.pid === "country" ||
@@ -471,11 +476,6 @@
 				this.drawCircles();
 			}
 
-			if (this.pid === "country" || this.pid === "ovotovata") {
-				this.drawGrid();
-			} else {
-				this.drawDashedGrid();
-			}
 			this.drawBorders();
 
 			if (this.pid !== "onsen") {
@@ -560,13 +560,26 @@
 			}
 		}
 	},
-	"Graphic@doubleback,simpleloop,rassi": {
+	"Graphic@simpleloop": {
 		getBGCellColor: function(cell) {
 			return cell.ques === 7 ? "black" : this.getBGCellColor_error1(cell);
-		},
+		}
+	},
+	"Graphic@doubleback,rassi": {
+		getBGCellColor: function(cell) {
+			return cell.ques === 7 ? "darkgray" : this.getBGCellColor_error1(cell);
+		}
+	},
+	"Graphic@simpleloop,doubleback,rassi": {
 		getBorderColor: function(border) {
 			var cell1 = border.sidecell[0],
 				cell2 = border.sidecell[1];
+			if (cell1.ques === 7 && cell2.ques === 7) {
+				return null;
+			}
+			if (this.pid === "simpleloop" && (cell1.ques === 7 || cell2.ques === 7)) {
+				return null;
+			}
 			if (
 				border.inside &&
 				!cell1.isnull &&


### PR DESCRIPTION
simpleloop, doubleback, rassi: "empty" cell drawing tweaks
    
    - move the grid drawing earlier, so that the empty cell shading
      covers the grid lines (so we don't see the dashed lines when
      we don't draw borders)
    - for simpleloop, avoid drawing thick borders around empty cells,
      to fix ugliness when two empty cells touch diagonally
    - for doubleback and rassi, that fix doesn't work due to room
      borders, so instead shade empty cells dark gray (and don't draw
      borders between empty cells)
