### PR TITLE
yinyang: Move display setting to Panel

### DIFF
--- a/src-ui/p.html
+++ b/src-ui/p.html
@@ -66,7 +66,6 @@ if ('serviceWorker' in navigator) {
        <li data-value="2"><span>__font.serif__</span></li>
      </menu></li>
      <hr>
-     <li class="check" data-config="dispqnumbg"><span>__dispqnumbg__</span></li>
      <li class="check" data-config="undefcell"><span>__undefcell__</span></li>
      <li class="check" data-config="cursor"><span>__cursor__</span></li>
      <li class="check" data-config="trialmarker"><span>__trialmarker__</span></li>
@@ -313,6 +312,12 @@ if ('serviceWorker' in navigator) {
       <label>
         <input type="checkbox">
         <span>__context_marks__</span>
+      </label>
+    </div>
+    <div class="config" data-config="dispqnumbg">
+      <label>
+        <input type="checkbox">
+        <span>__dispqnumbg__</span>
       </label>
     </div>
     <div class="config" data-config="keypopup">


### PR DESCRIPTION
This was hidden away in the menus, where nobody thinks to look for a genre-specific setting. The panel currently hosts display options for Yajilin, International Borders, Hebi-Ichigo, Context and Koburin.