### PR TITLE
lapaz: simplify graph handling, tweak style

### DIFF
--- a/src/variety/lapaz.js
+++ b/src/variety/lapaz.js
@@ -195,7 +195,7 @@
 		gridcolor_type: "LIGHT",
 		bgcellcolor_func: "qsub1",
 
-		qanscolor: "rgb(0, 80, 0)",
+		qanscolor: "black",
 
 		paint: function() {
 			this.drawBGCells();


### PR DESCRIPTION
Originally I just wanted to do something about the dark green borders (they're barely distinguishable from black and look a bit "dirty" to me).

As a side effect that I don't understand at all, left clicking a shaded cell now turns it explicitly unshaded. I'm not sure why this previously turned back to entirely unset -- was that deliberate or an accidental side-effect of the ghost border implementation?