### PR TITLE
shwolf: fix encoding of 1xn and nx1 grids (fixes #262)

### DIFF
--- a/src/variety-common/Encode.js
+++ b/src/variety-common/Encode.js
@@ -732,7 +732,10 @@ pzpr.classmgr.makeCommon({
 					count = 0;
 				}
 			}
-			if (count > 0) {
+			if (count > 0 || cm === "") {
+				// cm == "" && count == 0 happens for 1xn / nx1 boards
+				// with no potential crosses. This is encoded as "0" as
+				// "all 0 of the 0 potential crosses are not crosses"
 				cm += count.toString(36);
 			}
 

--- a/test/variety/shwolf_test.js
+++ b/test/variety/shwolf_test.js
@@ -1,0 +1,19 @@
+var assert = require("assert");
+
+var pzpr = require("../../");
+
+var puzzle = new pzpr.Puzzle();
+
+describe("Variety:shwolf", function() {
+	it("Encodes a small puzzle well", function() {
+		puzzle.open("shwolf/1/1");
+		puzzle.setMode("edit");
+		puzzle.cursor.init(1, 1);
+		puzzle.key.inputKeys("1");
+		assert.equal(puzzle.board.getc(1, 1).qnum, 1);
+		var url = puzzle.getURL();
+		var puzzle2 = new pzpr.Puzzle();
+		puzzle2.open(url);
+		assert.equal(puzzle2.board.getc(1, 1).qnum, 1);
+	});
+});


### PR DESCRIPTION
The encoding of the dots (encodeCrossMarks) was emitting an empty string, while the decoding was consuming one character.

The change encodes the crosses of such a grid as "0", which is consistent in that absence of crosses is generally encoded as the number of potential crosses, i.e., all crosses are skipped.

The only other puzzle type that uses encodeCrossMarks is bdblock,
which uses it with `cross: 2` hence is not affected.