### PR TITLE
remove autocheck guard for dominion and chained block

### DIFF
--- a/src-ui/js/ui/MenuConfig.js
+++ b/src-ui/js/ui/MenuConfig.js
@@ -20,7 +20,7 @@
 			this.list = {};
 
 			/* 正解自動判定機能 */
-			this.add("autocheck_mode", "simple", {
+			this.add("autocheck_mode", "guarded", {
 				option: ["off", "simple", "guarded"]
 			});
 

--- a/src/variety/chainedb.js
+++ b/src/variety/chainedb.js
@@ -205,8 +205,7 @@
 			"checkUniqueShapes",
 			"checkNoNumberInShade",
 			"checkNumberAndShadeSize",
-			"checkNoChain",
-			"doneShadingDecided"
+			"checkNoChain"
 		],
 
 		checkNoNumberInShade: function() {

--- a/src/variety/dominion.js
+++ b/src/variety/dominion.js
@@ -109,8 +109,7 @@
 			"checkNoNumber",
 			"checkGatheredObject",
 			"checkSingleShadeCell",
-			"checkSameNumberInBlock",
-			"doneShadingDecided"
+			"checkSameNumberInBlock"
 		],
 		checkOverShadeCell: function() {
 			this.checkAllArea(


### PR DESCRIPTION
There seems to be no real need for it for these puzzles -- you generally know they're done when you place the last black cell. (There might well be a couple more among the new puzzles that could have it removed.)

Also restores the default autocheck setting to guarded, which I missed in the merge.