### PR TITLE
Fix undo/redo of turnflip with arrow

### DIFF
--- a/src/variety-common/BoardExec.js
+++ b/src/variety-common/BoardExec.js
@@ -71,6 +71,11 @@ pzpr.classmgr.makeCommon({
 		},
 		getTranslateDir: function(key) {
 			var trans = {};
+			// Just return current qdir when undo/redo
+			// to avoid double conversion at redo time
+			if (this.puzzle.opemgr.disrec) {
+				return {1: 1, 2: 2, 3: 3, 4: 4}
+			}
 			switch (key) {
 				case this.FLIPY:
 					trans = { 1: 2, 2: 1 };

--- a/src/variety-common/BoardExec.js
+++ b/src/variety-common/BoardExec.js
@@ -74,7 +74,7 @@ pzpr.classmgr.makeCommon({
 			// Just return current qdir when undo/redo
 			// to avoid double conversion at redo time
 			if (this.puzzle.opemgr.disrec) {
-				return {1: 1, 2: 2, 3: 3, 4: 4}
+				return { 1: 1, 2: 2, 3: 3, 4: 4 };
 			}
 			switch (key) {
 				case this.FLIPY:


### PR DESCRIPTION
I've fixed bug of undo-redoing of turn/flip operation in the puzzles which have arrows. 
Issue #394 for more information