### PR TITLE
Add "Outline shaded cells" button to slitherlink

### DIFF
--- a/src-ui/js/ui/ToolArea.js
+++ b/src-ui/js/ui/ToolArea.js
@@ -346,6 +346,9 @@ ui.toolarea = {
 	resetblocks: function() {
 		ui.puzzle.board.operate("resetpos");
 	},
+	outlineshaded: function() {
+		ui.puzzle.board.operate("outlineshaded");
+	},
 	flushexcell: function() {
 		ui.puzzle.board.flushexcell();
 	},

--- a/src-ui/p.html
+++ b/src-ui/p.html
@@ -452,7 +452,7 @@ if ('serviceWorker' in navigator) {
   <button type="button" class="btn" id="btnflush"   data-button-exec="flushexcell">__flushexcell__</button>
   <button type="button" class="btn" id="btnpresets" data-button-exec="applypreset">__applypreset__</button>
   <button type="button" class="btn" data-disp-pid="stostone" data-press-exec="dropblocks,resetblocks">__dropblocks__</button>
-  <button type="button" class="btn" data-disp-pid="slither" data-press-exec="outlineshaded">__outlineshaded__</button>
+  <button type="button" class="btn" data-disp-pid="slither" data-button-exec="outlineshaded">__outlineshaded__</button>
   <button type="button" class="btn" id="btntrial"   data-button-exec="enterTrial">__enterTrial__</button>
   <div id="btntrialarea" style="display:none;">
     <button type="button" class="btn btn-ok" id="btntriala"  data-button-exec="acceptTrial">__acceptTrial__</button

--- a/src-ui/p.html
+++ b/src-ui/p.html
@@ -452,6 +452,7 @@ if ('serviceWorker' in navigator) {
   <button type="button" class="btn" id="btnflush"   data-button-exec="flushexcell">__flushexcell__</button>
   <button type="button" class="btn" id="btnpresets" data-button-exec="applypreset">__applypreset__</button>
   <button type="button" class="btn" data-disp-pid="stostone" data-press-exec="dropblocks,resetblocks">__dropblocks__</button>
+  <button type="button" class="btn" data-disp-pid="slither" data-press-exec="outlineshaded">__outlineshaded__</button>
   <button type="button" class="btn" id="btntrial"   data-button-exec="enterTrial">__enterTrial__</button>
   <div id="btntrialarea" style="display:none;">
     <button type="button" class="btn btn-ok" id="btntriala"  data-button-exec="acceptTrial">__acceptTrial__</button

--- a/src-ui/res/p.en.json
+++ b/src-ui/res/p.en.json
@@ -213,6 +213,7 @@
     "applypreset.title": "Replace bank",
     "applypreset.submit": "Replace",
     "dropblocks": "Drop blocks",
+    "outlineshaded": "Outline shaded cells",
     "enterTrial": "Trial mode",
     "acceptTrial": "Accept trial",
     "rejectTrial": "Reject trial",

--- a/src/variety/slither.js
+++ b/src/variety/slither.js
@@ -110,9 +110,7 @@
 
 		outlineShaded: function() {
 			this.border.each(function(border) {
-				// if (border) {
 				border.updateShaded();
-				// }
 			});
 		}
 	},

--- a/src/variety/slither.js
+++ b/src/variety/slither.js
@@ -95,7 +95,44 @@
 
 	Board: {
 		hasborder: 2,
-		borderAsLine: true
+		borderAsLine: true,
+
+		operate: function(type) {
+			switch (type) {
+				case "outlineshaded":
+					this.outlineShaded();
+					break;
+				default:
+					this.common.operate.call(this, type);
+					break;
+			}
+		},
+
+		outlineShaded: function() {
+			this.border.each(function(border) {
+				// if (border) {
+				border.updateShaded();
+				// }
+			});
+		}
+	},
+
+	Border: {
+		updateShaded: function() {
+			var c0 = this.sidecell[0],
+				c1 = this.sidecell[1];
+			var qsub1 = c0.isnull ? 2 : c0.qsub;
+			var qsub2 = c1.isnull ? 2 : c1.qsub;
+			if (qsub1 === 0 || qsub2 === 0) {
+				return;
+			}
+			if (qsub1 === qsub2) {
+				this.setLineVal(0);
+			} else {
+				this.setLine();
+			}
+			this.draw();
+		}
 	},
 
 	LineGraph: {

--- a/test/variety/slither_test.js
+++ b/test/variety/slither_test.js
@@ -1,4 +1,4 @@
-// test/variety/slitherlink_test.js
+// test/variety/slither_test.js
 
 var assert = require("assert");
 

--- a/test/variety/slitherlink_test.js
+++ b/test/variety/slitherlink_test.js
@@ -1,0 +1,53 @@
+// test/variety/slitherlink_test.js
+
+var assert = require("assert");
+
+var pzpr = require("../../");
+
+var puzzle = new pzpr.Puzzle();
+
+describe("Variety:slither", function() {
+	it("Outline shaded cells functions correctly", function() {
+		puzzle.open("slither/2/4/dbh");
+		puzzle.setMode("play");
+		puzzle.mouse.setInputMode("auto");
+		puzzle.mouse.inputPath("left", 4, 0, 4, 2);
+		puzzle.mouse.inputPath("left", 2, 4, 4, 4);
+		puzzle.mouse.inputPath("left", 2, 6, 4, 6);
+		puzzle.mouse.inputPath("left", 0, 8, 4, 8);
+		puzzle.mouse.inputPath("left", 2, 3);
+		puzzle.mouse.inputPath("left", 2, 5);
+		puzzle.mouse.inputPath("left", 1, 4);
+		puzzle.mouse.inputPath("left", 1, 6);
+		puzzle.mouse.setInputMode("bgcolor1");
+		puzzle.mouse.inputPath("left", 1, 1, 1, 7);
+		puzzle.mouse.setInputMode("bgcolor2");
+		puzzle.mouse.inputPath("left", 3, 1);
+		puzzle.mouse.inputPath("left", 3, 5);
+
+		puzzle.board.operate("outlineshaded");
+		var bd = puzzle.board.freezecopy();
+
+		puzzle.open("slither/2/4/dbh");
+		puzzle.setMode("play");
+		puzzle.mouse.setInputMode("auto");
+		puzzle.mouse.inputPath("left", 2, 2, 2, 0, 0, 0, 0, 8, 4, 8);
+		puzzle.mouse.inputPath("left", 4, 4, 2, 4, 2, 6, 4, 6);
+		puzzle.mouse.inputPath("left", 2, 3);
+		puzzle.mouse.inputPath("left", 1, 4);
+		puzzle.mouse.inputPath("left", 1, 6);
+		puzzle.mouse.setInputMode("bgcolor1");
+		puzzle.mouse.inputPath("left", 1, 1, 1, 7);
+		puzzle.mouse.setInputMode("bgcolor2");
+		puzzle.mouse.inputPath("left", 3, 1);
+		puzzle.mouse.inputPath("left", 3, 5);
+
+		puzzle.board.compareData(bd, function(group, c, a) {
+			assert.equal(
+				bd[group][c][a],
+				puzzle.board[group][c][a],
+				group + "[" + c + "]." + a
+			);
+		});
+	});
+});


### PR DESCRIPTION
I solve slitherlink puzzles via shading the cells, which has some advantages (easier to see connectivity, less inputs required overall).  However at the end of the puzzle this requires going back over in Line mode and outlining all the green cells in order for the answer checker to trigger.  I added a button to do this outlining automatically so that the experience of solving via shading is more user-friendly.

Here are before/after screenshots showing the new button's behavior.
![Screenshot_2023-07-14_22-03-25](https://github.com/robx/pzprjs/assets/1123944/e71e81de-67c7-458b-97a2-f21a59e0f093)
![Screenshot_2023-07-14_22-03-42](https://github.com/robx/pzprjs/assets/1123944/885db203-43a9-4674-b97a-d85ec96edbb3)
