### PR TITLE
fix undo behavior

### DIFF
--- a/src/puzzle/Operation.js
+++ b/src/puzzle/Operation.js
@@ -483,6 +483,15 @@ pzpr.classmgr.makeCommon({
 		push: function(ope) {
 			this[this.length++] = ope;
 		},
+		pop: function() {
+			if (this.length > 0) {
+				var ope = this[this.length - 1];
+				delete this[this.length - 1];
+				this.length--;
+				return ope;
+			}
+			return null;
+		},
 		some: function(func) {
 			return Array.prototype.slice.call(this).some(func);
 		}
@@ -716,8 +725,12 @@ pzpr.classmgr.makeCommon({
 			} else {
 				/* merged into previous operation, remove if noop */
 				if (this.lastope.isNoop && this.lastope.isNoop()) {
-					this.history.pop();
-					this.position--;
+					if (this.history[this.history.length - 1].length <= 1) {
+						this.history.pop();
+						this.position--;
+					} else {
+						this.history[this.history.length - 1].pop();
+					}
 					this.lastope = null;
 				}
 			}


### PR DESCRIPTION
It seems that there exists an undo bug. This request is to fix the bug.

### How to reproduce the bug
1. open the pencils page
2. change the mode to play mode
3. click the same edge twice
then, ctrl+z cannot delete the edge anymore.

### Why did this bug occur?
previously, the `opemgr` removes the last element of the history object if the `lastope` is noop.
however, this element is an array of operations, and may have other operation than the `lastope`, so this action may lose some other operation from histories.