### PR TITLE
Fix Bosnian Road shading input

### DIFF
--- a/src/variety/bosnianroad.js
+++ b/src/variety/bosnianroad.js
@@ -28,7 +28,7 @@
 					(this.mousestart || this.mousemove) &&
 					(!this.firstCell.isnull || this.notInputted())
 				) {
-					this.inputcell();
+					this.inputShade();
 				}
 				if (this.mouseend && this.notInputted()) {
 					this.inputqcmp();
@@ -59,6 +59,11 @@
 		},
 
 		inputShade: function() {
+			if (this.puzzle.playmode) {
+				this.inputcell();
+				return;
+			}
+
 			var cell = this.getcell();
 			if (cell.isnull || cell === this.mouseCell) {
 				return;
@@ -67,7 +72,7 @@
 				this.inputData = cell.qnum === -1 ? -2 : -1;
 			}
 			if ((this.inputData === -1) !== (cell.qnum === -1)) {
-				cell.setQnum(this.inputData);
+				cell.setNum(this.inputData);
 				cell.drawaround();
 			}
 			this.mouseCell = cell;

--- a/test/script/bosnianroad.js
+++ b/test/script/bosnianroad.js
@@ -36,5 +36,30 @@ ui.debug.addDebugData("bosnianroad", {
 			"pzprv3/bosnianroad/7/7/. . . . . . . /. 2 . . . 4 . /. . . . . . . /. . . . . . . /. . . . . . . /. - . . . 7 . /. . . . . . . /+ + + + + + + /+ . # # # . + /+ + # + # # # /+ + # + + + # /+ + # # # + # /+ . + + # . # /+ + + + # # # /"
 		]
 	],
-	inputs: []
+	inputs: [
+		{
+			label: "Gray cells",
+			input: ["newboard,3,3", "editmode,auto", "mouse,right, 1,1, 1,5"],
+			result:
+				"pzprv3/bosnianroad/3/3/- . . /- . . /- . . /. . . /. . . /. . . /"
+		},
+		{
+			label: "Shaded cells",
+			input: ["playmode,shade", "mouse,left, 1,1, 5,1"],
+			result:
+				"pzprv3/bosnianroad/3/3/- . . /- . . /- . . /. # # /. . . /. . . /"
+		},
+		{
+			label: "Unshaded cells",
+			input: ["playmode,unshade", "mouse,left, 1,5, 5,5"],
+			result:
+				"pzprv3/bosnianroad/3/3/- . . /- . . /- . . /. # # /. . . /. + + /"
+		},
+		{
+			label: "Gray cells on top of answer",
+			input: ["editmode,shade", "mouse,left, 5,1, 5,5"],
+			result:
+				"pzprv3/bosnianroad/3/3/- . - /- . - /- . - /. # . /. . . /. + . /"
+		}
+	]
 });


### PR DESCRIPTION
While Auto mode worked correctly for this, using Shaded Cells or Unshaded Cells modes while solving would place or remove gray cells instead, allowing the player to erase the puzzle. Whoops.

More subtly, placing gray cells while editing would fail to erase underlying shaded/unshaded cells.

This PR fixes both bugs.