### PR TITLE
Fixed KinKonKan decoding

### DIFF
--- a/src/variety/kinkonkan.js
+++ b/src/variety/kinkonkan.js
@@ -508,14 +508,13 @@
 			for (var i = 0; i < bstr.length; i++) {
 				var ca = bstr.charAt(i),
 					excell = bd.excell[ec];
-
 				if (this.include(ca, "A", "Z")) {
 					subint.push(ec);
 					excell.qchar = parseInt(ca, 36) - 9;
 				} else if (this.include(ca, "0", "9")) {
 					subint.push(ec);
 					excell.qchar =
-						parseInt(ca, 36) - 9 + (parseInt(bstr.charAt(i + 1), 10) + 1) * 26;
+						parseInt(bstr.charAt(i + 1), 36) - 9 + (parseInt(ca, 10) + 1) * 26;
 					i++;
 				} else if (this.include(ca, "a", "z")) {
 					ec += parseInt(ca, 36) - 10;


### PR DESCRIPTION
The issue was that the encoding for letters that are not normal upper case letters are encoded of the form 0A, first number indicating if it is upper case or blue and the second is the letter. The decoder was parsing the first character as the letter and the second character as a number, resulting in the second yielding NaN. Swapping the two characters fixes it