### PR TITLE
Fix question marks for Dominion

### DIFF
--- a/src/variety/dominion.js
+++ b/src/variety/dominion.js
@@ -129,7 +129,7 @@
 			this.checkAllBlock(
 				this.board.ublkmgr,
 				function(cell) {
-					return cell.isNum();
+					return cell.isValidNum();
 				},
 				function(w, h, a, n) {
 					return a !== 0;


### PR DESCRIPTION
I have noticed that there is no check for if numbers are actually shaded. Given that it is impossible to shade them in normal play, is this fine?