### PR TITLE
Peke in LITS

### DIFF
--- a/src/variety/lits.js
+++ b/src/variety/lits.js
@@ -253,11 +253,13 @@
 				this.decodeAreaRoom();
 			}
 			this.decodeCellAns();
+			this.decodeBorderLine();
 		},
 		encodeData: function() {
 			this.filever = 1;
 			this.encodeBorderQues();
 			this.encodeCellAns();
+			this.encodeBorderLineIfPresent();
 		},
 
 		kanpenOpen: function() {

--- a/src/variety/lits.js
+++ b/src/variety/lits.js
@@ -27,7 +27,28 @@
 	"MouseEvent@lits,invlitso": {
 		inputModes: {
 			edit: ["border", "info-blk"],
-			play: ["shade", "unshade", "info-blk"]
+			play: ["shade", "unshade", "peke", "info-blk"]
+		},
+		mouseinput_auto: function() {
+			if (this.puzzle.playmode) {
+				if (
+					this.btn === "right" &&
+					this.mousestart &&
+					this.inputpeke_ifborder()
+				) {
+					return;
+				}
+				if (
+					(this.mousestart || this.mousemove) &&
+					(!this.firstCell.isnull || this.notInputted())
+				) {
+					this.inputcell();
+				}
+			} else if (this.puzzle.editmode) {
+				if (this.mousestart || this.mousemove) {
+					this.inputborder();
+				}
+			}
 		}
 	},
 	"MouseEvent@norinori": {
@@ -171,6 +192,7 @@
 			this.drawGrid();
 
 			this.drawBorders();
+			this.drawPekes();
 
 			this.drawChassis();
 		}


### PR DESCRIPTION
## Summary

Adds an X ("peke") mark to LITS borders to indicate that at most one of the two cells they divide would be shaded.
Matching the affordance already used in Yajilin and several other varieties: right-clicking directly on the border between two cells in play mode toggles a solving-aid X mark there, independent of cell shading.

- Right-click on a border toggles the mark (`inputpeke_ifborder`); right-click inside a cell still unshades as before, and left-click still shades. A drag that starts on a border won't also shade/unshade the cell it ends on.
- Marks survive local save/load (`decodeBorderLine`/`encodeBorderLineIfPresent`), the same pattern used by `heyawake.js`/`hitori.js`. They are not written into the shareable URL, matching how most non-line puzzles treat this kind of scratch mark.

<img width="247" height="338" alt="Screenshot 2026-08-11 at 10 41 38" src="https://github.com/user-attachments/assets/c2d7223e-c597-4491-8c4e-d9cf27ecf003" />
