### PR TITLE
jatahoku: Trim unused clue margins in player mode

### DIFF
--- a/src/variety/jatahoku.js
+++ b/src/variety/jatahoku.js
@@ -522,6 +522,35 @@
 				}
 			}
 			return list;
+		},
+		getClueOffsets: function() {
+			var left = this.minbx / -2,
+				top = this.minby / -2;
+
+			for (var bx = this.minbx + 1; bx < 0; bx += 2) {
+				for (var by = 1; by < this.maxby; by += 2) {
+					if (this.getex(bx, by).qnum !== -1) {
+						left = (this.minbx + 1 - bx) / -2;
+						bx = 0;
+						break;
+					}
+				}
+			}
+
+			for (var by = this.minby + 1; by < 0; by += 2) {
+				for (var bx = 1; bx < this.maxbx; bx += 2) {
+					if (this.getex(bx, by).qnum !== -1) {
+						top = (this.minby + 1 - by) / -2;
+						by = 0;
+						break;
+					}
+				}
+			}
+
+			return [
+				Math.min(left, Math.max(0, this.minbx / -2 - 2)),
+				Math.min(top, Math.max(0, this.minby / -2 - 1))
+			];
 		}
 	},
 
@@ -746,6 +775,22 @@
 		cursorIsOnBoard: function() {
 			var cursor = this.puzzle.cursor;
 			return cursor.by <= this.board.maxby;
+		},
+		getBoardCols: function() {
+			return this.getOffsetCols() + this.board.maxbx / 2;
+		},
+		getBoardRows: function() {
+			return this.getOffsetRows() + this.board.maxby / 2;
+		},
+		getOffsetCols: function() {
+			var bd = this.board,
+				offset = this.puzzle.playeronly ? bd.getClueOffsets()[0] : 0;
+			return (0 - bd.minbx) / 2 - offset;
+		},
+		getOffsetRows: function() {
+			var bd = this.board,
+				offset = this.puzzle.playeronly ? bd.getClueOffsets()[1] : 0;
+			return (0 - bd.minby) / 2 - offset;
 		}
 	},
 

--- a/test/variety/jatahoku_test.js
+++ b/test/variety/jatahoku_test.js
@@ -31,6 +31,18 @@ describe("Variety:jatahoku", function() {
 		assert.equal(board.indicator.count, 5);
 	});
 
+	it("trims unused top and left clue space in the player", function() {
+		var player = new pzpr.Puzzle({ type: "player" }).open("jatahoku/6/6");
+		var editor = new pzpr.Puzzle({ type: "editor" }).open("jatahoku/6/6");
+		player.board.getex(1, -1).qnum = 3;
+		player.board.getex(-1, 1).qnum = 3;
+
+		assert.equal(editor.painter.getBoardCols(), 10);
+		assert.equal(editor.painter.getBoardRows(), 10);
+		assert.equal(player.painter.getBoardCols(), 9);
+		assert.equal(player.painter.getBoardRows(), 8);
+	});
+
 	it("round-trips gray clues and one/two digit unknown sums", function() {
 		var puzzle = new pzpr.Puzzle().open("jatahoku/6/6");
 		var board = puzzle.board;


### PR DESCRIPTION
## Summary

Reduce unused space for the top and left clues in the JaTaHoKu player view.

The drawing offsets are now calculated based on the positions of the outer clues. The editor keeps the full clue area available for input.

## Before

Excessive space was displayed above and to the left of the grid.

`jatahoku/9/9/4/4gi289144gi28900003vo000vu0000/vz29_/vzk_qz18_qz16_/`
<img width="794" height="887" alt="image" src="https://github.com/user-attachments/assets/03e7059b-70db-4655-9fe0-5b22bc023420" />

## After

Unused clue space is trimmed, placing the grid closer to the surrounding UI.

`jatahoku/9/9/4/4gi289144gi28900003vo000vu0000/vz29_/vzk_qz18_qz16_/`
<img width="770" height="845" alt="image" src="https://github.com/user-attachments/assets/b974f907-34c0-4685-91cc-4d2702be4f24" />

## Testing

- Added a test covering the adjusted player dimensions
- Confirmed that the editor dimensions remain unchanged